### PR TITLE
feat: release v0.1.2 local skill governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.1.2
+
+- Added governance commands:
+  - `all-local-skills`
+  - `skill-detail`
+  - `tag set`
+  - `tag list`
+  - `cleanup --plan|--apply|--rollback`
+- Added registry schema `version: 2` with canonical path keys and legacy key index compatibility.
+- Added skill policy tags:
+  - `regular`
+  - `disabled`
+  - `frozen`
+  - `deleted` (soft delete)
+- Added structure manifest parsing for multi-file skills and manifest-hash based duplicate detection.
+- Aligned `skill-md` parsing with `vercel-labs/skills` conventions:
+  - require YAML frontmatter
+  - require string `name` + `description`
+  - honor `metadata.internal: true` with `INSTALL_INTERNAL_SKILLS` opt-in
+- Added priority discovery compatibility for `skill-md`:
+  - common skill directories
+  - `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` declared paths
+- Switched frontmatter parsing to `gray-matter`.
+- Added `doctor --skills-spec` checks for:
+  - skill frontmatter/spec conventions
+  - plugin marketplace manifest path safety
+- Added cleanup planner + apply + rollback workflow using `cleanupHistory`.
+- Updated `scan` to:
+  - upsert by canonical path
+  - respect `frozen` immutability for content-derived fields
+  - maintain legacy key aliases
+- Updated `sync` to exclude `disabled` and `deleted` skills by default.
+- Updated `doctor` to validate canonical registry index integrity.
+- Added governance tests and updated smoke flow.
+- Updated docs (`README.md`, `COMPATIBILITY.md`) and bumped CLI/package version to `0.1.2`.
+
 ## 0.1.1
 
 - Added built-in agent registry (`bin/agent-registry.json`) for OpenClaw + Core presets.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Compatibility Matrix
 
-SkillsDock v0.1.1 supports both **user scope** and **project scope** for each built-in agent preset.
+SkillsDock v0.1.2 supports both **user scope** and **project scope** for each built-in agent preset.
 
 ## Agent Path Matrix
 
@@ -24,18 +24,33 @@ SkillsDock v0.1.1 supports both **user scope** and **project scope** for each bu
 | `openclaw-md` | `*.md` |
 | `opencode-md` | `*.md` |
 
+## `skill-md` Compatibility Notes
+
+- `SKILL.md` must contain YAML frontmatter with string `name` and `description`.
+- `metadata.internal: true` is skipped by default during scan.
+  - Set `INSTALL_INTERNAL_SKILLS=1` or `INSTALL_INTERNAL_SKILLS=true` to include internal skills.
+- Scan discovery follows the same priority style as `vercel-labs/skills`:
+  - common directories (such as `skills/`, `.agents/skills/`, `.claude/skills/`, `.codex/skills/`, etc.)
+  - `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` declared skill paths
+  - recursive scan fallback
+- Frontmatter parsing is powered by `gray-matter`.
+- `skillsdock doctor --skills-spec` validates spec-convention compliance and plugin manifest path safety.
+
 ## Sync Format Behavior
 
 - Same format + non-package source: symlink (default mode) or copy.
 - `.skill` source package: extracted and copied as converted content.
 - Cross-format sync: converted and copied.
 - If symlink fails and fallback is `copy`, SkillsDock writes copied content and reports a warning.
+- Governance tag behavior:
+  - `regular` and `frozen` are eligible for sync.
+  - `disabled` and `deleted` are excluded from sync.
 
 ## Platform Support
 
 - Required and validated in CI: **macOS**, **Linux**.
 - Node versions in CI: **18**, **20**, **22**.
-- Windows support is not guaranteed in v0.1.1.
+- Windows support is not guaranteed in v0.1.2.
 
 ## Reference Note
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,23 @@
 
 This repository is intentionally **CLI-only**.
 
-## What Changed In v0.1.1
+## What Changed In v0.1.2
 
-- Built-in agent registry for OpenClaw + Core agent presets.
-- Dual-scope paths for every built-in agent (`user` + `project`).
-- Format-aware sync with default `symlink` mode and safe copy fallback.
-- Config schema upgraded to `version: 2` with non-destructive migration.
-- `doctor --agents` compatibility matrix.
-- CI matrix for macOS + Linux (Node 18/20/22).
+- Added governance views:
+  - `all-local-skills`
+  - `skill-detail`
+- Added lifecycle tags:
+  - `regular`
+  - `disabled`
+  - `frozen`
+  - `deleted` (soft delete)
+- Added cleanup workflow:
+  - `cleanup --plan`
+  - `cleanup --apply`
+  - `cleanup --rollback <runId>`
+- Upgraded registry to canonical-path identity with legacy-key index compatibility.
+- Added structure manifests for multi-file skills and manifest hash based duplicate detection.
+- `sync` now skips `disabled` and `deleted` by default.
 
 ## Design Principle
 
@@ -42,8 +51,17 @@ skillsdock init
 # scan configured sources
 skillsdock scan
 
-# view primary active skills
-skillsdock list
+# governance view
+skillsdock all-local-skills
+
+# inspect one skill (path/key/id selector)
+skillsdock skill-detail my-skill --all-copies
+
+# mark a skill as frozen
+skillsdock tag set my-skill --tag frozen --reason "manual lock"
+
+# preview cleanup actions
+skillsdock cleanup --plan
 
 # dry-run sync to OpenClaw user scope
 skillsdock sync --to openclaw --scope user --dry-run
@@ -54,10 +72,16 @@ skillsdock sync --to openclaw --scope user --dry-run
 ```bash
 skillsdock init [--config <path>] [--registry <path>]
 skillsdock scan [paths...] [--config <path>] [--registry <path>]
+skillsdock all-local-skills [--config <path>] [--registry <path>] [--source <name>] [--scope <user|project>] [--tag <tag>] [--all] [--json]
+skillsdock skill-detail <selector> [--registry <path>] [--all-copies] [--json]
+skillsdock tag set <selector> --tag <regular|disabled|frozen|deleted> [--reason <text>] [--all-copies] [--registry <path>]
+skillsdock tag list [--registry <path>] [--source <name>] [--scope <user|project>] [--tag <tag>] [--all] [--json]
+skillsdock cleanup --plan|--apply [--registry <path>] [--source <name>] [--scope <user|project>] [--all] [--json]
+skillsdock cleanup --rollback <runId> [--registry <path>]
 skillsdock list [--config <path>] [--registry <path>] [--source <name>] [--changed] [--all] [--json]
-skillsdock inspect <id|key> [--registry <path>] [--json]
+skillsdock inspect <id|key|path> [--registry <path>] [--json]
 skillsdock sync --to <agent|target> --scope <user|project> [--config <path>] [--registry <path>] [--mode <symlink|copy>] [--fallback <copy|fail>] [--dry-run] [--all]
-skillsdock doctor [--config <path>] [--registry <path>] [--agents]
+skillsdock doctor [--config <path>] [--registry <path>] [--agents] [--skills-spec]
 skillsdock version
 ```
 
@@ -95,6 +119,25 @@ Behavior:
 - `mdc` (`*.mdc`)
 - `openclaw-md` (`*.md`)
 - `opencode-md` (`*.md`)
+
+### `skill-md` Parsing Rules (v0.1.2)
+
+SkillsDock v0.1.2 aligns local `SKILL.md` parsing with the conventions used by [vercel-labs/skills](https://github.com/vercel-labs/skills):
+
+- `SKILL.md` must include YAML frontmatter.
+- Frontmatter must include string `name` and string `description`.
+- `metadata.internal: true` is treated as internal and skipped by default.
+  - Set `INSTALL_INTERNAL_SKILLS=1` (or `true`) to include internal skills in `scan`.
+- Discovery prioritizes common skills directories and `.claude-plugin` manifest-declared paths, then recursively scans as fallback.
+- Frontmatter parsing uses [gray-matter](https://github.com/jonschlinkert/gray-matter) for compatibility and YAML edge cases.
+
+### Skills Spec Validation
+
+Use `doctor --skills-spec` to validate local `skill-md` sources against the [Agent Skills specification](https://agentskills.io) conventions:
+
+- validates `SKILL.md` parseability and required frontmatter fields
+- validates name style (recommended lowercase + hyphen, up to 64 chars)
+- validates `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` path safety and local-path conventions
 
 ## Config (v2)
 
@@ -143,14 +186,24 @@ Default config file: `~/.skillsdock/config.json`
 
 SkillsDock stores metadata in `~/.skillsdock/registry.json`.
 
-Each entry includes:
+Registry version `2` includes:
 
-- source info (`sourceName`, `sourcePath`, `sourceFormat`)
-- skill identity (`id`, `name`, `description`)
-- normalized content (`normalized.name`, `normalized.description`, `normalized.body`)
-- timestamps (`firstSeenAt`, `lastSeenAt`, `changedAt`, `createdAt`, `updatedAt`)
-- content hash (`sha256`)
-- primary selection (`isPrimary`)
+- canonical keys (`path:/abs/path/to/skill/SKILL.md`)
+- compatibility indexes:
+  - `index.byCanonicalPath`
+  - `index.byLegacyKey`
+- item policy fields:
+  - `policy.tag`
+  - `policy.reason`
+  - `policy.updatedAt`
+- structure manifest fields:
+  - `structureManifest.entryFile`
+  - `structureManifest.includedFiles`
+  - `structureManifest.fileHashes`
+  - `manifestHash`
+- cleanup history:
+  - `cleanupHistory[].runId`
+  - `cleanupHistory[].actions[]`
 
 ## Compatibility Matrix
 

--- a/bin/skillsdock-core.mjs
+++ b/bin/skillsdock-core.mjs
@@ -6,9 +6,10 @@ import path from 'node:path';
 import process from 'node:process';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import matter from 'gray-matter';
 
 const APP_NAME = 'skillsdock';
-const APP_VERSION = '0.1.1';
+const APP_VERSION = '0.1.2';
 
 const HOME = os.homedir();
 const APP_DIR = path.join(HOME, '.skillsdock');
@@ -23,18 +24,84 @@ const VALID_SCOPE_SET = new Set(['user', 'project']);
 const VALID_FORMAT_SET = new Set(['skill-md', 'mdc', 'openclaw-md', 'opencode-md']);
 const VALID_SYNC_MODE_SET = new Set(['symlink', 'copy']);
 const VALID_FALLBACK_SET = new Set(['copy', 'fail']);
+const VALID_TAG_SET = new Set(['regular', 'disabled', 'frozen', 'deleted']);
+
+const TAG_PRIORITY = {
+  frozen: 4,
+  regular: 3,
+  disabled: 2,
+  deleted: 1
+};
+
+const MANIFEST_LIMITS = {
+  maxFiles: 200,
+  maxTotalBytes: 2 * 1024 * 1024
+};
 
 const DEFAULT_SCAN = {
   maxDepth: 8,
   ignoreDirs: ['node_modules', '.git', '.next', 'dist', 'build', '.turbo', '.cache']
 };
 
+const SKILL_DISCOVERY_PRIORITY_DIRS = [
+  'skills',
+  'skills/.curated',
+  'skills/.experimental',
+  'skills/.system',
+  '.agent/skills',
+  '.agents/skills',
+  '.augment/skills',
+  '.claude/skills',
+  '.cline/skills',
+  '.codebuddy/skills',
+  '.codex/skills',
+  '.commandcode/skills',
+  '.continue/skills',
+  '.cortex/skills',
+  '.crush/skills',
+  '.factory/skills',
+  '.goose/skills',
+  '.iflow/skills',
+  '.junie/skills',
+  '.kilocode/skills',
+  '.kiro/skills',
+  '.kode/skills',
+  '.mcpjam/skills',
+  '.mux/skills',
+  '.neovate/skills',
+  '.opencode/skills',
+  '.openhands/skills',
+  '.pi/skills',
+  '.pochi/skills',
+  '.qoder/skills',
+  '.qwen/skills',
+  '.roo/skills',
+  '.trae/skills',
+  '.vibe/skills',
+  '.windsurf/skills',
+  '.zencoder/skills',
+  '.adal/skills'
+];
+
+const SKILL_NAME_SPEC_REGEX = /^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$/;
+
 const DEFAULT_REGISTRY = {
-  version: 1,
+  version: 2,
   lastScanAt: null,
   updatedAt: null,
-  items: {}
+  items: {},
+  index: {
+    byCanonicalPath: {},
+    byLegacyKey: {}
+  },
+  cleanupHistory: []
 };
+
+function makeCliError(message, exitCode = 1) {
+  const error = new Error(message);
+  error.exitCode = exitCode;
+  return error;
+}
 
 function loadAgentRegistry() {
   try {
@@ -110,6 +177,59 @@ function sha256(text) {
   return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
 }
 
+function sha256Buffer(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function normalizePath(inputPath) {
+  return path.resolve(expandHomePath(String(inputPath || '')));
+}
+
+function makeCanonicalKey(canonicalPath) {
+  return `path:${canonicalPath}`;
+}
+
+function extractLegacyPathFromKey(key) {
+  const raw = String(key || '');
+  const index = raw.indexOf(':');
+  if (index < 0 || index === raw.length - 1) return null;
+  return raw.slice(index + 1);
+}
+
+function hasTag(item, tag) {
+  return String(item?.policy?.tag || 'regular') === tag;
+}
+
+function isDeleted(item) {
+  return hasTag(item, 'deleted');
+}
+
+function isFrozen(item) {
+  return hasTag(item, 'frozen');
+}
+
+function shouldIncludeByTag(item, flags = {}) {
+  if (flags.all) return true;
+  return !isDeleted(item);
+}
+
+function isSyncEligible(item) {
+  const tag = String(item?.policy?.tag || 'regular');
+  return tag === 'regular' || tag === 'frozen';
+}
+
+function shouldInstallInternalSkills() {
+  const envValue = String(process.env.INSTALL_INTERNAL_SKILLS || '').toLowerCase();
+  return envValue === '1' || envValue === 'true';
+}
+
+function isInternalSkillMetadata(metadata) {
+  if (!metadata || typeof metadata !== 'object') return false;
+  const meta = metadata.metadata;
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return false;
+  return meta.internal === true;
+}
+
 function yamlQuote(value) {
   return JSON.stringify(String(value ?? ''));
 }
@@ -164,34 +284,17 @@ function resolveTemplatePath(inputPath, options = {}) {
 
 function parseFrontmatter(raw) {
   const content = String(raw || '').replace(/\r\n/g, '\n');
-  if (!content.startsWith('---\n')) {
-    return { metadata: {}, body: content.trim() };
+  const hasFrontmatter = /^---[ \t]*\n[\s\S]*?\n---[ \t]*(?:\n|$)/.test(content);
+  try {
+    const parsed = matter(content);
+    return {
+      metadata: parsed.data && typeof parsed.data === 'object' ? parsed.data : {},
+      body: String(parsed.content || '').trim(),
+      hasFrontmatter
+    };
+  } catch {
+    return { metadata: {}, body: content.trim(), hasFrontmatter: false };
   }
-
-  const end = content.indexOf('\n---\n', 4);
-  if (end < 0) {
-    return { metadata: {}, body: content.trim() };
-  }
-
-  const metaBlock = content.slice(4, end);
-  const body = content.slice(end + 5).trim();
-  const metadata = {};
-
-  for (const line of metaBlock.split('\n')) {
-    const idx = line.indexOf(':');
-    if (idx <= 0) continue;
-    const key = line.slice(0, idx).trim();
-    let value = line.slice(idx + 1).trim();
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-    metadata[key] = value;
-  }
-
-  return { metadata, body };
 }
 
 function inferNameFromPath(filePath) {
@@ -298,6 +401,175 @@ function tryGetGitMetadata(filePath) {
   };
 }
 
+function isContainedIn(targetPath, basePath) {
+  const normalizedBase = path.normalize(path.resolve(basePath));
+  const normalizedTarget = path.normalize(path.resolve(targetPath));
+  return normalizedTarget === normalizedBase || normalizedTarget.startsWith(`${normalizedBase}${path.sep}`);
+}
+
+function isValidRelativePluginPath(input) {
+  return typeof input === 'string' && input.startsWith('./');
+}
+
+async function readJsonIfExists(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function pushUniqueWarning(warnings, message) {
+  if (!warnings.includes(message)) warnings.push(message);
+}
+
+async function getPluginSkillSearchResult(basePath) {
+  const normalizedBasePath = path.resolve(basePath);
+  const dirs = [];
+  const seen = new Set();
+  const warnings = [];
+
+  const pushDir = (candidate, label) => {
+    const resolved = path.resolve(candidate);
+    if (!isContainedIn(resolved, normalizedBasePath)) {
+      pushUniqueWarning(
+        warnings,
+        `Plugin manifest path escaped source root (${label}): ${resolved} is outside ${normalizedBasePath}`
+      );
+      return;
+    }
+    if (seen.has(resolved)) return;
+    seen.add(resolved);
+    dirs.push(resolved);
+  };
+
+  const addPluginSkillDirs = (pluginBase, skills = [], label) => {
+    const resolvedPluginBase = path.resolve(pluginBase);
+    if (!isContainedIn(resolvedPluginBase, normalizedBasePath)) {
+      pushUniqueWarning(
+        warnings,
+        `Plugin base escaped source root (${label}): ${resolvedPluginBase} is outside ${normalizedBasePath}`
+      );
+      return;
+    }
+
+    if (Array.isArray(skills)) {
+      for (const skillPath of skills) {
+        if (!isValidRelativePluginPath(skillPath)) {
+          pushUniqueWarning(
+            warnings,
+            `Plugin skill path must start with "./" (${label}): ${String(skillPath)}`
+          );
+          continue;
+        }
+        pushDir(path.dirname(path.join(resolvedPluginBase, skillPath)), `${label} skill path`);
+      }
+    }
+
+    pushDir(path.join(resolvedPluginBase, 'skills'), `${label} default skills dir`);
+  };
+
+  const marketplacePath = path.join(normalizedBasePath, '.claude-plugin', 'marketplace.json');
+  const marketplace = await readJsonIfExists(marketplacePath);
+  if (marketplace && typeof marketplace === 'object' && !Array.isArray(marketplace)) {
+    let pluginRoot = '';
+    if (typeof marketplace.metadata?.pluginRoot === 'string') {
+      if (isValidRelativePluginPath(marketplace.metadata.pluginRoot)) {
+        pluginRoot = marketplace.metadata.pluginRoot;
+      } else {
+        pushUniqueWarning(
+          warnings,
+          `Invalid pluginRoot in marketplace.json: ${marketplace.metadata.pluginRoot} (must start with "./")`
+        );
+      }
+    }
+    const plugins = Array.isArray(marketplace.plugins) ? marketplace.plugins : [];
+    for (const [index, plugin] of plugins.entries()) {
+      if (!plugin || typeof plugin !== 'object') continue;
+      const label = `marketplace plugin #${index + 1}`;
+
+      if (plugin.source && typeof plugin.source !== 'string') {
+        pushUniqueWarning(
+          warnings,
+          `${label} uses non-local source and was ignored (only local string source is supported)`
+        );
+        continue;
+      }
+      if (typeof plugin.source === 'string' && !isValidRelativePluginPath(plugin.source)) {
+        pushUniqueWarning(
+          warnings,
+          `${label} source must start with "./": ${plugin.source}`
+        );
+        continue;
+      }
+
+      const pluginBase = path.join(normalizedBasePath, pluginRoot, plugin.source || '');
+      const skillPaths = Array.isArray(plugin.skills) ? plugin.skills : [];
+      addPluginSkillDirs(pluginBase, skillPaths, label);
+    }
+  } else if (marketplace !== null) {
+    pushUniqueWarning(warnings, `Invalid marketplace.json format: expected JSON object`);
+  }
+
+  const pluginPath = path.join(normalizedBasePath, '.claude-plugin', 'plugin.json');
+  const pluginManifest = await readJsonIfExists(pluginPath);
+  if (pluginManifest && typeof pluginManifest === 'object' && !Array.isArray(pluginManifest)) {
+    const skillPaths = Array.isArray(pluginManifest.skills) ? pluginManifest.skills : [];
+    addPluginSkillDirs(normalizedBasePath, skillPaths, 'plugin.json');
+  } else if (pluginManifest !== null) {
+    pushUniqueWarning(warnings, `Invalid plugin.json format: expected JSON object`);
+  }
+
+  return {
+    dirs,
+    warnings
+  };
+}
+
+async function getPluginSkillSearchDirs(basePath) {
+  const result = await getPluginSkillSearchResult(basePath);
+  return result.dirs;
+}
+
+async function collectPrioritySkillMdFiles(rootPath) {
+  const files = [];
+  const seen = new Set();
+
+  const addSkillFile = async (skillPath) => {
+    const resolved = path.resolve(skillPath);
+    if (seen.has(resolved)) return;
+    try {
+      const stat = await fs.stat(resolved);
+      if (!stat.isFile()) return;
+      seen.add(resolved);
+      files.push(resolved);
+    } catch {}
+  };
+
+  await addSkillFile(path.join(rootPath, 'SKILL.md'));
+
+  const priorityDirs = [rootPath, ...SKILL_DISCOVERY_PRIORITY_DIRS.map((dir) => path.join(rootPath, dir))];
+  const pluginSkillDirs = await getPluginSkillSearchDirs(rootPath);
+  priorityDirs.push(...pluginSkillDirs);
+
+  for (const dir of priorityDirs) {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      await addSkillFile(path.join(dir, entry.name, 'SKILL.md'));
+    }
+  }
+
+  return files;
+}
+
 async function collectSkillFiles(rootPath, format, maxDepth, ignoreDirs) {
   const fullRoot = path.resolve(rootPath);
   const ignoreSet = new Set(ignoreDirs || []);
@@ -332,8 +604,22 @@ async function collectSkillFiles(rootPath, format, maxDepth, ignoreDirs) {
     return isSkillFileNameForFormat(path.basename(fullRoot), format) ? [fullRoot] : [];
   }
 
+  if (format === 'skill-md') {
+    const priorityFiles = await collectPrioritySkillMdFiles(fullRoot);
+    files.push(...priorityFiles);
+  }
+
   await walk(fullRoot, 0);
-  return files;
+
+  const unique = [];
+  const seen = new Set();
+  for (const filePath of files) {
+    const resolved = path.resolve(filePath);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    unique.push(resolved);
+  }
+  return unique;
 }
 
 async function extractSkillMarkdownFromPackage(filePath) {
@@ -356,14 +642,208 @@ async function extractSkillMarkdownFromPackage(filePath) {
   return skillEntry.async('string');
 }
 
+async function getSkillPackageManifest(filePath) {
+  const parseWarnings = [];
+  const buffer = await fs.readFile(filePath);
+  const jszipModule = await import('jszip');
+  const JSZip = jszipModule.default;
+  const zip = await JSZip.loadAsync(buffer);
+
+  const entries = Object.entries(zip.files)
+    .filter(([, value]) => !value.dir)
+    .map(([name]) => name)
+    .sort((a, b) => a.localeCompare(b));
+
+  const fileHashes = {};
+  const includedFiles = [];
+  let totalBytes = 0;
+  let truncated = false;
+  let skillMarkdown = null;
+
+  for (const name of entries) {
+    if (includedFiles.length >= MANIFEST_LIMITS.maxFiles) {
+      truncated = true;
+      break;
+    }
+    const zipEntry = zip.file(name);
+    if (!zipEntry) continue;
+    const contentBuffer = await zipEntry.async('nodebuffer');
+    totalBytes += contentBuffer.byteLength;
+    if (totalBytes > MANIFEST_LIMITS.maxTotalBytes) {
+      truncated = true;
+      break;
+    }
+    includedFiles.push(name);
+    fileHashes[name] = sha256Buffer(contentBuffer);
+
+    if (!skillMarkdown && name.toLowerCase().endsWith('skill.md')) {
+      skillMarkdown = contentBuffer.toString('utf8');
+    }
+  }
+
+  if (!skillMarkdown) {
+    throw new Error(`No SKILL.md found inside package: ${filePath}`);
+  }
+  if (truncated) {
+    parseWarnings.push(
+      `Manifest truncated at maxFiles=${MANIFEST_LIMITS.maxFiles} maxTotalBytes=${MANIFEST_LIMITS.maxTotalBytes}`
+    );
+  }
+
+  const manifestHash = sha256(
+    Object.entries(fileHashes)
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([relPath, hash]) => `${relPath}:${hash}`)
+      .join('\n')
+  );
+
+  return {
+    raw: skillMarkdown,
+    manifest: {
+      entryFile: 'SKILL.md',
+      rootDir: filePath,
+      includedFiles,
+      fileHashes,
+      manifestHash,
+      parseWarnings
+    }
+  };
+}
+
+async function buildDirectoryManifest(rootDir, entryPath, ignoreDirs = []) {
+  const parseWarnings = [];
+  const ignoreSet = new Set([...(ignoreDirs || []), '.git']);
+  const fileHashes = {};
+  const includedFiles = [];
+  let totalBytes = 0;
+  let truncated = false;
+
+  async function walk(currentPath) {
+    if (truncated) return;
+    let entries;
+    try {
+      entries = await fs.readdir(currentPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      if (truncated) return;
+      const fullPath = path.join(currentPath, entry.name);
+
+      if (entry.isSymbolicLink()) {
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        if (ignoreSet.has(entry.name)) continue;
+        await walk(fullPath);
+        continue;
+      }
+
+      if (!entry.isFile()) continue;
+
+      if (includedFiles.length >= MANIFEST_LIMITS.maxFiles) {
+        truncated = true;
+        return;
+      }
+
+      const buffer = await fs.readFile(fullPath);
+      totalBytes += buffer.byteLength;
+      if (totalBytes > MANIFEST_LIMITS.maxTotalBytes) {
+        truncated = true;
+        return;
+      }
+
+      const relativePath = path.relative(rootDir, fullPath).split(path.sep).join('/');
+      includedFiles.push(relativePath);
+      fileHashes[relativePath] = sha256Buffer(buffer);
+    }
+  }
+
+  await walk(rootDir);
+
+  if (truncated) {
+    parseWarnings.push(
+      `Manifest truncated at maxFiles=${MANIFEST_LIMITS.maxFiles} maxTotalBytes=${MANIFEST_LIMITS.maxTotalBytes}`
+    );
+  }
+
+  const manifestHash = sha256(
+    Object.entries(fileHashes)
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([relPath, hash]) => `${relPath}:${hash}`)
+      .join('\n')
+  );
+
+  return {
+    entryFile: path.basename(entryPath),
+    rootDir,
+    includedFiles,
+    fileHashes,
+    manifestHash,
+    parseWarnings
+  };
+}
+
+async function buildStructureManifest(filePath, sourceFormat, ignoreDirs = []) {
+  const resolvedPath = path.resolve(filePath);
+  const ext = path.extname(resolvedPath).toLowerCase();
+
+  if (sourceFormat === 'skill-md' && ext === '.skill') {
+    const pkg = await getSkillPackageManifest(resolvedPath);
+    return pkg.manifest;
+  }
+
+  if (sourceFormat === 'mdc') {
+    const buffer = await fs.readFile(resolvedPath);
+    const hash = sha256Buffer(buffer);
+    return {
+      entryFile: path.basename(resolvedPath),
+      rootDir: path.dirname(resolvedPath),
+      includedFiles: [path.basename(resolvedPath)],
+      fileHashes: { [path.basename(resolvedPath)]: hash },
+      manifestHash: hash,
+      parseWarnings: []
+    };
+  }
+
+  const rootDir = path.dirname(resolvedPath);
+  const manifest = await buildDirectoryManifest(rootDir, resolvedPath, ignoreDirs);
+  if (sourceFormat === 'openclaw-md' || sourceFormat === 'opencode-md' || sourceFormat === 'skill-md') {
+    if (manifest.entryFile.toLowerCase() !== 'skill.md') {
+      manifest.parseWarnings.push(
+        `Entry file is ${manifest.entryFile}; expected SKILL.md for ${sourceFormat}`
+      );
+    }
+  }
+  return manifest;
+}
+
 function parseContentForFormat(format, raw, filePath) {
   const sourceFormat = normalizeSourceFormat(format, filePath);
 
   if (sourceFormat === 'skill-md') {
-    const { metadata, body } = parseFrontmatter(raw);
+    const { metadata, body, hasFrontmatter } = parseFrontmatter(raw);
+    const name = metadata?.name;
+    const description = metadata?.description;
+    if (!hasFrontmatter) {
+      throw new Error(`Invalid SKILL.md at ${filePath}: missing YAML frontmatter`);
+    }
+    if (
+      typeof name !== 'string' ||
+      typeof description !== 'string' ||
+      name.trim().length === 0 ||
+      description.trim().length === 0
+    ) {
+      throw new Error(
+        `Invalid SKILL.md at ${filePath}: frontmatter must include string "name" and "description"`
+      );
+    }
     const normalized = {
-      name: String(metadata.name || inferNameFromPath(filePath)),
-      description: String(metadata.description || firstBodyLine(body)),
+      name: name.trim(),
+      description: description.trim(),
       body: normalizeBody(body)
     };
     return { metadata, normalized };
@@ -371,9 +851,17 @@ function parseContentForFormat(format, raw, filePath) {
 
   if (sourceFormat === 'mdc' || sourceFormat === 'openclaw-md' || sourceFormat === 'opencode-md') {
     const { metadata, body } = parseFrontmatter(raw);
+    const name =
+      typeof metadata?.name === 'string' && metadata.name.trim().length > 0
+        ? metadata.name.trim()
+        : inferNameFromPath(filePath);
+    const description =
+      typeof metadata?.description === 'string' && metadata.description.trim().length > 0
+        ? metadata.description.trim()
+        : firstBodyLine(body || raw);
     const normalized = {
-      name: String(metadata.name || inferNameFromPath(filePath)),
-      description: String(metadata.description || firstBodyLine(body || raw)),
+      name,
+      description,
       body: normalizeBody(body || raw)
     };
     return { metadata, normalized };
@@ -648,14 +1136,232 @@ function normalizeConfigV2(input, projectRoot = detectProjectRoot(process.cwd())
   };
 }
 
+function normalizeIsoOrNull(value) {
+  return toIso(value) || null;
+}
+
+function normalizePolicy(inputPolicy, now = null) {
+  const policy = inputPolicy && typeof inputPolicy === 'object' ? inputPolicy : {};
+  const tag = VALID_TAG_SET.has(policy.tag) ? policy.tag : 'regular';
+  return {
+    tag,
+    reason: String(policy.reason || ''),
+    updatedAt: normalizeIsoOrNull(policy.updatedAt) || now
+  };
+}
+
+function normalizeStructureManifest(manifest, canonicalPath, fileHash = null) {
+  if (!manifest || typeof manifest !== 'object') {
+    return {
+      entryFile: path.basename(canonicalPath),
+      rootDir: path.dirname(canonicalPath),
+      includedFiles: [path.basename(canonicalPath)],
+      fileHashes: fileHash ? { [path.basename(canonicalPath)]: fileHash } : {},
+      manifestHash: fileHash || null,
+      parseWarnings: []
+    };
+  }
+
+  const includedFiles = Array.isArray(manifest.includedFiles)
+    ? manifest.includedFiles.filter((entry) => typeof entry === 'string')
+    : [path.basename(canonicalPath)];
+
+  const fileHashes =
+    manifest.fileHashes && typeof manifest.fileHashes === 'object' && !Array.isArray(manifest.fileHashes)
+      ? manifest.fileHashes
+      : {};
+
+  return {
+    entryFile: String(manifest.entryFile || path.basename(canonicalPath)),
+    rootDir: String(manifest.rootDir || path.dirname(canonicalPath)),
+    includedFiles,
+    fileHashes,
+    manifestHash: String(manifest.manifestHash || manifest.hash || fileHash || ''),
+    parseWarnings: Array.isArray(manifest.parseWarnings)
+      ? manifest.parseWarnings.map((entry) => String(entry))
+      : []
+  };
+}
+
+function toTimestampForSort(value) {
+  const iso = toIso(value);
+  if (!iso) return 0;
+  return Date.parse(iso) || 0;
+}
+
+function mergeNonEmptyStrings(primary, fallback) {
+  const p = String(primary || '').trim();
+  if (p.length > 0) return p;
+  return String(fallback || '');
+}
+
+function mergeRegistryItems(existing, incoming) {
+  if (!existing) return incoming;
+  const existingTs = Math.max(
+    toTimestampForSort(existing.updatedAt),
+    toTimestampForSort(existing.lastSeenAt),
+    toTimestampForSort(existing.changedAt)
+  );
+  const incomingTs = Math.max(
+    toTimestampForSort(incoming.updatedAt),
+    toTimestampForSort(incoming.lastSeenAt),
+    toTimestampForSort(incoming.changedAt)
+  );
+
+  const latest = incomingTs >= existingTs ? incoming : existing;
+  const older = latest === incoming ? existing : incoming;
+
+  const merged = {
+    ...older,
+    ...latest
+  };
+
+  merged.legacyKeys = Array.from(new Set([...(existing.legacyKeys || []), ...(incoming.legacyKeys || [])]));
+  merged.policy = normalizePolicy(
+    {
+      ...(older.policy || {}),
+      ...(latest.policy || {})
+    },
+    latest.policy?.updatedAt || older.policy?.updatedAt || null
+  );
+  merged.normalized = {
+    name: mergeNonEmptyStrings(latest.normalized?.name, older.normalized?.name),
+    description: mergeNonEmptyStrings(latest.normalized?.description, older.normalized?.description),
+    body: mergeNonEmptyStrings(latest.normalized?.body, older.normalized?.body)
+  };
+  merged.name = mergeNonEmptyStrings(latest.name, older.name || merged.normalized.name);
+  merged.description = mergeNonEmptyStrings(latest.description, older.description || merged.normalized.description);
+  merged.content = mergeNonEmptyStrings(latest.content, older.content);
+  merged.hash = mergeNonEmptyStrings(latest.hash, older.hash);
+  merged.manifestHash = mergeNonEmptyStrings(latest.manifestHash, older.manifestHash || merged.hash);
+  merged.structureManifest = normalizeStructureManifest(
+    latest.structureManifest || older.structureManifest,
+    merged.canonicalPath,
+    merged.hash
+  );
+  merged.createdAt = normalizeIsoOrNull(latest.createdAt) || normalizeIsoOrNull(older.createdAt);
+  merged.updatedAt = normalizeIsoOrNull(latest.updatedAt) || normalizeIsoOrNull(older.updatedAt);
+  merged.firstSeenAt = normalizeIsoOrNull(older.firstSeenAt) || normalizeIsoOrNull(latest.firstSeenAt);
+  merged.lastSeenAt = normalizeIsoOrNull(latest.lastSeenAt) || normalizeIsoOrNull(older.lastSeenAt);
+  merged.changedAt = normalizeIsoOrNull(latest.changedAt) || normalizeIsoOrNull(older.changedAt);
+  merged.state = latest.state || older.state || 'active';
+  return merged;
+}
+
+function normalizeCleanupHistory(input) {
+  if (!Array.isArray(input)) return [];
+  const rows = [];
+  for (const entry of input) {
+    if (!entry || typeof entry !== 'object') continue;
+    const actions = Array.isArray(entry.actions)
+      ? entry.actions
+          .filter((action) => action && typeof action === 'object' && typeof action.key === 'string')
+          .map((action) => ({
+            key: action.key,
+            beforeTag: VALID_TAG_SET.has(action.beforeTag) ? action.beforeTag : 'regular',
+            beforeReason: String(action.beforeReason || ''),
+            afterTag: VALID_TAG_SET.has(action.afterTag) ? action.afterTag : 'regular',
+            afterReason: String(action.afterReason || '')
+          }))
+      : [];
+    rows.push({
+      runId: String(entry.runId || ''),
+      createdAt: normalizeIsoOrNull(entry.createdAt),
+      actions
+    });
+  }
+  return rows.filter((entry) => entry.runId.length > 0);
+}
+
+function rebuildRegistryIndexes(registry) {
+  const byCanonicalPath = {};
+  const byLegacyKey = {};
+  for (const [key, item] of Object.entries(registry.items || {})) {
+    if (!item || typeof item !== 'object') continue;
+    const canonicalPath = String(item.canonicalPath || '');
+    if (canonicalPath) {
+      byCanonicalPath[canonicalPath] = key;
+    }
+    const legacyKeys = Array.isArray(item.legacyKeys) ? item.legacyKeys : [];
+    for (const legacyKey of legacyKeys) {
+      if (typeof legacyKey !== 'string' || legacyKey.length === 0) continue;
+      byLegacyKey[legacyKey] = key;
+    }
+  }
+  registry.index = {
+    byCanonicalPath,
+    byLegacyKey
+  };
+  return registry;
+}
+
+function makeRegistryItemFromUnknown(rawItem, legacyKey = '') {
+  const item = rawItem && typeof rawItem === 'object' ? rawItem : {};
+  const sourcePath = item.canonicalPath || item.sourcePath || extractLegacyPathFromKey(legacyKey) || legacyKey;
+  const canonicalPath = normalizePath(sourcePath);
+  const key = makeCanonicalKey(canonicalPath);
+  const hash = String(item.hash || '');
+  const normalized = {
+    name: String(item.normalized?.name || item.name || inferNameFromPath(canonicalPath)),
+    description: String(item.normalized?.description || item.description || ''),
+    body: String(item.normalized?.body || item.body || '')
+  };
+  const manifestHash = String(item.manifestHash || hash);
+  const legacyKeys = Array.from(
+    new Set(
+      [legacyKey, ...(Array.isArray(item.legacyKeys) ? item.legacyKeys : [])].filter(
+        (entry) => typeof entry === 'string' && entry.length > 0 && entry !== key
+      )
+    )
+  );
+
+  return {
+    ...item,
+    key,
+    canonicalPath,
+    sourcePath: canonicalPath,
+    legacyKeys,
+    id: String(item.id || slugify(normalized.name || inferNameFromPath(canonicalPath))),
+    name: String(item.name || normalized.name),
+    description: String(item.description || normalized.description || firstBodyLine(normalized.body)),
+    normalized,
+    isInternal: Boolean(item.isInternal) || isInternalSkillMetadata(item.metadata),
+    hash,
+    manifestHash,
+    policy: normalizePolicy(item.policy),
+    structureManifest: normalizeStructureManifest(item.structureManifest, canonicalPath, hash),
+    state: String(item.state || 'active'),
+    createdAt: normalizeIsoOrNull(item.createdAt),
+    updatedAt: normalizeIsoOrNull(item.updatedAt),
+    firstSeenAt: normalizeIsoOrNull(item.firstSeenAt),
+    lastSeenAt: normalizeIsoOrNull(item.lastSeenAt),
+    changedAt: normalizeIsoOrNull(item.changedAt)
+  };
+}
+
 function normalizeRegistry(input) {
   const data = input && typeof input === 'object' ? input : {};
-  return {
-    version: 1,
-    lastScanAt: data.lastScanAt || null,
-    updatedAt: data.updatedAt || null,
-    items: data.items && typeof data.items === 'object' ? data.items : {}
+  const sourceItems = data.items && typeof data.items === 'object' ? data.items : {};
+  const normalized = {
+    version: 2,
+    lastScanAt: normalizeIsoOrNull(data.lastScanAt),
+    updatedAt: normalizeIsoOrNull(data.updatedAt),
+    items: {},
+    index: {
+      byCanonicalPath: {},
+      byLegacyKey: {}
+    },
+    cleanupHistory: normalizeCleanupHistory(data.cleanupHistory)
   };
+
+  for (const [legacyKey, rawItem] of Object.entries(sourceItems)) {
+    const candidate = makeRegistryItemFromUnknown(rawItem, legacyKey);
+    const canonicalKey = candidate.key;
+    const existing = normalized.items[canonicalKey];
+    normalized.items[canonicalKey] = mergeRegistryItems(existing, candidate);
+  }
+
+  return rebuildRegistryIndexes(normalized);
 }
 
 function printHelp() {
@@ -665,15 +1371,24 @@ ${APP_NAME} v${APP_VERSION}
 Usage:
   skillsdock init [--config <path>] [--registry <path>]
   skillsdock scan [paths...] [--config <path>] [--registry <path>]
+  skillsdock all-local-skills [--config <path>] [--registry <path>] [--source <name>] [--scope <user|project>] [--tag <tag>] [--all] [--json]
+  skillsdock skill-detail <selector> [--registry <path>] [--all-copies] [--json]
+  skillsdock tag set <selector> --tag <regular|disabled|frozen|deleted> [--reason <text>] [--all-copies] [--registry <path>]
+  skillsdock tag list [--registry <path>] [--source <name>] [--scope <user|project>] [--tag <tag>] [--all] [--json]
+  skillsdock cleanup --plan|--apply [--registry <path>] [--source <name>] [--scope <user|project>] [--all] [--json]
+  skillsdock cleanup --rollback <runId> [--registry <path>]
   skillsdock list [--config <path>] [--registry <path>] [--source <name>] [--changed] [--all] [--json]
-  skillsdock inspect <id|key> [--registry <path>] [--json]
+  skillsdock inspect <id|key|path> [--registry <path>] [--json]
   skillsdock sync --to <agent|target> --scope <user|project> [--registry <path>] [--config <path>] [--mode <symlink|copy>] [--fallback <copy|fail>] [--dry-run] [--all]
-  skillsdock doctor [--config <path>] [--registry <path>] [--agents]
+  skillsdock doctor [--config <path>] [--registry <path>] [--agents] [--skills-spec]
   skillsdock version
 
 Examples:
   skillsdock init
   skillsdock scan ~/Coding ~/Work
+  skillsdock all-local-skills
+  skillsdock tag set lint-check --tag frozen --reason "manual lock"
+  skillsdock cleanup --plan
   skillsdock list --changed
   skillsdock sync --to openclaw --scope user --dry-run
 `);
@@ -740,14 +1455,19 @@ async function cmdInit(flags, context) {
   console.log('\nNext step: skillsdock scan');
 }
 
-async function parseSkillRecord(filePath, sourceName, sourceRoot, sourceFormat) {
+async function parseSkillRecord(filePath, source, sourceRoot, sourceFormat, scanConfig = DEFAULT_SCAN) {
+  const sourceName = source.name;
   const ext = path.extname(filePath).toLowerCase();
   let raw;
+  let manifest;
 
   if (sourceFormat === 'skill-md' && ext === '.skill') {
-    raw = await extractSkillMarkdownFromPackage(filePath);
+    const pkg = await getSkillPackageManifest(filePath);
+    raw = pkg.raw;
+    manifest = pkg.manifest;
   } else {
     raw = await fs.readFile(filePath, 'utf8');
+    manifest = await buildStructureManifest(filePath, sourceFormat, scanConfig.ignoreDirs);
   }
 
   const { metadata, normalized } = parseContentForFormat(sourceFormat, raw, filePath);
@@ -756,6 +1476,7 @@ async function parseSkillRecord(filePath, sourceName, sourceRoot, sourceFormat) 
 
   const id = slugify(normalized.name || inferNameFromPath(filePath));
   const description = String(normalized.description || firstBodyLine(normalized.body));
+  const isInternal = isInternalSkillMetadata(metadata);
 
   const resolvedSourceRoot = path.resolve(sourceRoot);
   let relativePath = path.basename(filePath);
@@ -770,11 +1491,14 @@ async function parseSkillRecord(filePath, sourceName, sourceRoot, sourceFormat) 
     name: normalized.name,
     description,
     metadata,
+    isInternal,
     normalized,
     content: raw,
     body: normalized.body,
     hash: sha256(raw),
     sourceName,
+    sourceAgent: source.agent || null,
+    sourceScope: source.scope || null,
     sourceRoot: resolvedSourceRoot,
     sourcePath: path.resolve(filePath),
     relativePath,
@@ -782,7 +1506,9 @@ async function parseSkillRecord(filePath, sourceName, sourceRoot, sourceFormat) 
     format: sourceFormat,
     createdAt: gitMeta?.createdAt || toIso(stat.birthtime) || toIso(stat.ctime),
     updatedAt: gitMeta?.updatedAt || toIso(stat.mtime),
-    originRepo: gitMeta?.originRepo || null
+    originRepo: gitMeta?.originRepo || null,
+    structureManifest: normalizeStructureManifest(manifest, path.resolve(filePath), sha256(raw)),
+    manifestHash: manifest?.manifestHash || sha256(raw)
   };
 }
 
@@ -798,7 +1524,9 @@ async function cmdScan(flags, positionalArgs, context) {
           name: `arg-${index + 1}`,
           path: inputPath,
           format: inferSourceFormatFromPath(inputPath),
-          optional: false
+          optional: false,
+          agent: null,
+          scope: null
         }))
       : config.sources;
 
@@ -806,21 +1534,30 @@ async function cmdScan(flags, positionalArgs, context) {
     throw new Error('No scan sources configured. Run "skillsdock init" and update config.');
   }
 
-  const seenKeys = new Set();
+  const seenCanonicalPaths = new Set();
   const sourceNames = [];
+  const includeInternal = shouldInstallInternalSkills();
   let discovered = 0;
   let created = 0;
   let updated = 0;
   let unchanged = 0;
   let parseErrors = 0;
+  let skippedInternal = 0;
 
-  for (const source of sourceInputs) {
-    const sourceName = source.name || slugify(source.path || 'source');
-    const sourcePathInput = source.path;
+  for (const sourceRaw of sourceInputs) {
+    const sourceName = sourceRaw.name || slugify(sourceRaw.path || 'source');
+    const sourcePathInput = sourceRaw.path;
     if (!sourcePathInput) continue;
 
     const sourcePath = resolveTemplatePath(sourcePathInput, { projectRoot });
-    const sourceFormat = normalizeSourceFormat(source.format, sourcePathInput);
+    const sourceFormat = normalizeSourceFormat(sourceRaw.format, sourcePathInput);
+    const source = {
+      ...sourceRaw,
+      name: sourceName,
+      agent: sourceRaw.agent || null,
+      scope: sourceRaw.scope || null,
+      format: sourceFormat
+    };
 
     sourceNames.push(sourceName);
 
@@ -833,27 +1570,59 @@ async function cmdScan(flags, positionalArgs, context) {
     discovered += skillFiles.length;
 
     for (const filePath of skillFiles) {
+      const canonicalPath = normalizePath(filePath);
+      seenCanonicalPaths.add(canonicalPath);
+      const canonicalKey = makeCanonicalKey(canonicalPath);
+      const legacyKey = `${sourceName}:${canonicalPath}`;
+      const existing = registry.items[canonicalKey];
+
+      if (existing && isFrozen(existing)) {
+        registry.items[canonicalKey] = {
+          ...existing,
+          key: canonicalKey,
+          canonicalPath,
+          sourcePath: canonicalPath,
+          sourceName,
+          sourceAgent: source.agent || existing.sourceAgent || null,
+          sourceScope: source.scope || existing.sourceScope || null,
+          sourceFormat: existing.sourceFormat || sourceFormat,
+          legacyKeys: Array.from(new Set([...(existing.legacyKeys || []), legacyKey])),
+          state: 'active',
+          firstSeenAt: existing.firstSeenAt || now,
+          lastSeenAt: now
+        };
+        unchanged += 1;
+        continue;
+      }
+
       let parsed;
       try {
-        parsed = await parseSkillRecord(filePath, sourceName, sourcePath, sourceFormat);
+        parsed = await parseSkillRecord(filePath, source, sourcePath, sourceFormat, config.scan);
       } catch {
         parseErrors += 1;
         continue;
       }
 
-      const key = `${sourceName}:${parsed.sourcePath}`;
-      seenKeys.add(key);
-      const existing = registry.items[key];
-      const changed = !existing || existing.hash !== parsed.hash;
+      if (parsed.isInternal && !includeInternal) {
+        skippedInternal += 1;
+        continue;
+      }
+
+      const changed =
+        !existing || existing.hash !== parsed.hash || (existing.manifestHash || '') !== parsed.manifestHash;
 
       if (!existing) created += 1;
       else if (changed) updated += 1;
       else unchanged += 1;
 
-      registry.items[key] = {
+      registry.items[canonicalKey] = {
         ...existing,
         ...parsed,
-        key,
+        key: canonicalKey,
+        canonicalPath,
+        sourcePath: canonicalPath,
+        legacyKeys: Array.from(new Set([...(existing?.legacyKeys || []), legacyKey])),
+        policy: normalizePolicy(existing?.policy, existing?.policy?.updatedAt || now),
         state: 'active',
         firstSeenAt: existing?.firstSeenAt || now,
         lastSeenAt: now,
@@ -864,9 +1633,9 @@ async function cmdScan(flags, positionalArgs, context) {
 
   let missing = 0;
   const scannedSourceSet = new Set(sourceNames);
-  for (const [key, item] of Object.entries(registry.items)) {
+  for (const [key, item] of Object.entries(registry.items || {})) {
     if (!scannedSourceSet.has(item.sourceName)) continue;
-    if (seenKeys.has(key)) continue;
+    if (seenCanonicalPaths.has(item.canonicalPath)) continue;
     if (item.state !== 'missing') missing += 1;
     registry.items[key] = {
       ...item,
@@ -876,8 +1645,9 @@ async function cmdScan(flags, positionalArgs, context) {
 
   const sourceOrder = new Map(sourceNames.map((name, index) => [name, index]));
   const byId = new Map();
-  for (const item of Object.values(registry.items)) {
+  for (const item of Object.values(registry.items || {})) {
     if (item.state !== 'active') continue;
+    if (isDeleted(item)) continue;
     if (!byId.has(item.id)) byId.set(item.id, []);
     byId.get(item.id).push(item);
   }
@@ -898,26 +1668,117 @@ async function cmdScan(flags, positionalArgs, context) {
 
   registry.lastScanAt = now;
   registry.updatedAt = now;
+  rebuildRegistryIndexes(registry);
   await writeJson(registryPath, registry);
 
   console.log(`Scanned ${sourceNames.length} source(s)`);
   console.log(`Found files: ${discovered}`);
   console.log(`New: ${created} | Updated: ${updated} | Unchanged: ${unchanged} | Missing: ${missing}`);
+  if (skippedInternal > 0) {
+    console.log(`Skipped internal skills: ${skippedInternal} (set INSTALL_INTERNAL_SKILLS=1 to include)`);
+  }
   if (parseErrors > 0) console.log(`Parse errors: ${parseErrors}`);
   console.log(`Registry: ${registryPath}`);
 }
 
-function filterListItems(items, flags, registry) {
-  let list = items.filter((item) => (flags.all ? true : item.state === 'active'));
+function toArrayUnique(values) {
+  return Array.from(new Set(values));
+}
+
+function getRegistryItems(registry) {
+  return Object.values(registry.items || {}).filter((item) => item && typeof item === 'object');
+}
+
+function normalizeSelectorToCanonicalPath(selector) {
+  try {
+    return normalizePath(selector);
+  } catch {
+    return null;
+  }
+}
+
+function resolveSelectorMatches(registry, selector, options = {}) {
+  const allowAllCopies = Boolean(options.allCopies);
+  const includeDeleted = Boolean(options.includeDeleted);
+  const items = getRegistryItems(registry);
+  const byCanonicalPath = registry.index?.byCanonicalPath || {};
+  const byLegacyKey = registry.index?.byLegacyKey || {};
+
+  const canonicalPathCandidate = normalizeSelectorToCanonicalPath(selector);
+  if (canonicalPathCandidate && byCanonicalPath[canonicalPathCandidate]) {
+    const key = byCanonicalPath[canonicalPathCandidate];
+    const item = registry.items[key];
+    if (!item) return [];
+    if (!includeDeleted && isDeleted(item)) return [];
+    return [item];
+  }
+
+  if (registry.items[selector]) {
+    const item = registry.items[selector];
+    if (!includeDeleted && isDeleted(item)) return [];
+    return [item];
+  }
+
+  if (byLegacyKey[selector]) {
+    const item = registry.items[byLegacyKey[selector]];
+    if (!item) return [];
+    if (!includeDeleted && isDeleted(item)) return [];
+    return [item];
+  }
+
+  const idMatches = items.filter((item) => item.id === selector);
+  const visibleMatches = includeDeleted ? idMatches : idMatches.filter((item) => !isDeleted(item));
+  if (visibleMatches.length <= 1 || allowAllCopies) {
+    return visibleMatches;
+  }
+
+  throw makeCliError(
+    `Selector "${selector}" matched ${visibleMatches.length} skills by id. Use --all-copies or provide key/path.`,
+    2
+  );
+}
+
+function filterBySharedFlags(items, flags = {}) {
+  let list = [...items];
 
   if (flags.source) {
     list = list.filter((item) => item.sourceName === flags.source);
   }
 
+  if (flags.scope) {
+    list = list.filter((item) => item.sourceScope === flags.scope);
+  }
+
+  if (flags.tag) {
+    list = list.filter((item) => String(item.policy?.tag || 'regular') === String(flags.tag));
+  }
+
+  if (!flags.all) {
+    list = list.filter((item) => !isDeleted(item));
+  }
+
+  return list;
+}
+
+function formatTagForDisplay(tag) {
+  return String(tag || 'regular');
+}
+
+function filterListItems(items, flags, registry) {
+  let list = items.filter((item) => (flags.all ? true : item.state === 'active'));
+  list = filterBySharedFlags(list, flags);
+
+  if (!flags.all) list = list.filter((item) => item.state === 'active');
+
   if (flags.changed) {
     const changedIds = new Set(
       items
-        .filter((item) => item.state === 'active' && item.changedAt === registry.lastScanAt)
+        .filter(
+          (item) =>
+            item.state === 'active' &&
+            item.changedAt === registry.lastScanAt &&
+            (flags.all ? true : !isDeleted(item))
+        )
         .map((item) => item.id)
     );
     list = list.filter((item) => changedIds.has(item.id));
@@ -932,7 +1793,7 @@ function filterListItems(items, flags, registry) {
 
 async function cmdList(flags) {
   const { registry } = await loadRegistry(flags.registry);
-  const items = Object.values(registry.items || {});
+  const items = getRegistryItems(registry);
   const list = filterListItems(items, flags, registry).sort((a, b) => a.id.localeCompare(b.id));
 
   if (flags.json) {
@@ -949,6 +1810,7 @@ async function cmdList(flags) {
     { label: 'ID', get: (row) => row.id, min: 12, max: 34 },
     { label: 'Source', get: (row) => row.sourceName, min: 8, max: 22 },
     { label: 'Format', get: (row) => row.sourceFormat, min: 8, max: 12 },
+    { label: 'Tag', get: (row) => formatTagForDisplay(row.policy?.tag), min: 8, max: 10 },
     { label: 'State', get: (row) => row.state, min: 8, max: 10 },
     { label: 'Updated', get: (row) => (row.updatedAt || '').slice(0, 19), min: 19, max: 19 },
     { label: 'Path', get: (row) => row.sourcePath, min: 20, max: 80 }
@@ -960,29 +1822,31 @@ async function cmdList(flags) {
 async function cmdInspect(flags, positionalArgs) {
   const query = positionalArgs[0];
   if (!query) {
-    throw new Error('Usage: skillsdock inspect <id|key>');
+    throw makeCliError('Usage: skillsdock inspect <id|key|path>', 2);
   }
 
   const { registry } = await loadRegistry(flags.registry);
-  const items = Object.values(registry.items || {});
-
-  let matched = items.find((item) => item.key === query);
-  if (!matched) {
-    const candidates = items.filter((item) => item.id === query && item.state === 'active');
-    matched = candidates.find((item) => item.isPrimary) || candidates[0];
+  const allCopies = Boolean(flags['all-copies'] || flags.allCopies);
+  const matches = resolveSelectorMatches(registry, query, {
+    allCopies: true,
+    includeDeleted: true
+  });
+  if (matches.length === 0) {
+    throw makeCliError(`Skill not found: ${query}`, 2);
   }
-  if (!matched) {
-    throw new Error(`Skill not found: ${query}`);
-  }
+  const matched = matches.find((item) => item.isPrimary) || matches[0];
 
+  const items = getRegistryItems(registry);
   const siblings = items
     .filter((item) => item.id === matched.id)
     .map((item) => ({
       key: item.key,
+      canonicalPath: item.canonicalPath,
       sourceName: item.sourceName,
       sourcePath: item.sourcePath,
       sourceFormat: item.sourceFormat,
       state: item.state,
+      tag: item.policy?.tag || 'regular',
       isPrimary: Boolean(item.isPrimary)
     }));
 
@@ -1001,10 +1865,12 @@ async function cmdInspect(flags, positionalArgs) {
   console.log(`Description: ${matched.description}`);
   console.log(`Source: ${matched.sourceName}`);
   console.log(`Format: ${matched.sourceFormat}`);
-  console.log(`Path: ${matched.sourcePath}`);
+  console.log(`Path: ${matched.canonicalPath || matched.sourcePath}`);
   console.log(`State: ${matched.state}`);
+  console.log(`Tag: ${formatTagForDisplay(matched.policy?.tag)}`);
   console.log(`Primary: ${matched.isPrimary ? 'yes' : 'no'}`);
   console.log(`Hash: ${matched.hash}`);
+  console.log(`Manifest Hash: ${matched.manifestHash || '-'}`);
   console.log(`Created: ${matched.createdAt || '-'}`);
   console.log(`Updated: ${matched.updatedAt || '-'}`);
   console.log(`First Seen: ${matched.firstSeenAt || '-'}`);
@@ -1013,9 +1879,477 @@ async function cmdInspect(flags, positionalArgs) {
   console.log(`\nCopies: ${siblings.length}`);
   for (const sibling of siblings) {
     console.log(
-      `- ${sibling.isPrimary ? '[primary] ' : ''}${sibling.sourceName} (${sibling.sourceFormat}): ${sibling.sourcePath}`
+      `- ${sibling.isPrimary ? '[primary] ' : ''}${sibling.sourceName} (${sibling.sourceFormat}, ${sibling.tag}): ${
+        sibling.canonicalPath || sibling.sourcePath
+      }`
     );
   }
+}
+
+function deriveAgentName(item) {
+  if (item.sourceAgent) return item.sourceAgent;
+  if (typeof item.sourceName === 'string' && item.sourceName.includes('-')) {
+    return item.sourceName.split('-')[0];
+  }
+  return 'unknown';
+}
+
+function computeSkillType(entries) {
+  const scopes = new Set(entries.map((entry) => entry.sourceScope).filter(Boolean));
+  if (scopes.size === 1 && scopes.has('user')) return 'global';
+  if (scopes.size === 1 && scopes.has('project')) return 'project';
+  return 'mixed';
+}
+
+function aggregateAllLocalSkills(items) {
+  const groups = new Map();
+  for (const item of items) {
+    const groupKey = String(item.normalized?.name || item.id || item.name || '').trim().toLowerCase();
+    const key = groupKey || String(item.id || item.key);
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key).push(item);
+  }
+
+  const rows = [];
+  for (const entries of groups.values()) {
+    const tags = toArrayUnique(entries.map((entry) => entry.policy?.tag || 'regular')).sort((a, b) =>
+      a.localeCompare(b)
+    );
+    const latestUpdatedAt = entries.reduce((acc, entry) => {
+      if (!entry.updatedAt) return acc;
+      if (!acc) return entry.updatedAt;
+      return toTimestampForSort(entry.updatedAt) > toTimestampForSort(acc) ? entry.updatedAt : acc;
+    }, null);
+    rows.push({
+      name: entries[0].normalized?.name || entries[0].name || entries[0].id,
+      type: computeSkillType(entries),
+      agents: toArrayUnique(entries.map((entry) => deriveAgentName(entry))).sort((a, b) => a.localeCompare(b)),
+      formats: toArrayUnique(entries.map((entry) => entry.sourceFormat).filter(Boolean)).sort((a, b) =>
+        a.localeCompare(b)
+      ),
+      copies: entries.length,
+      tag: tags.length === 1 ? tags[0] : 'mixed',
+      updatedAt: latestUpdatedAt,
+      items: entries
+    });
+  }
+
+  rows.sort((a, b) => {
+    const aTime = toTimestampForSort(a.updatedAt);
+    const bTime = toTimestampForSort(b.updatedAt);
+    if (aTime !== bTime) return bTime - aTime;
+    return a.name.localeCompare(b.name);
+  });
+  return rows;
+}
+
+async function cmdAllLocalSkills(flags) {
+  const { registry } = await loadRegistry(flags.registry);
+  const list = filterBySharedFlags(
+    getRegistryItems(registry).filter((item) => item.state === 'active'),
+    flags
+  );
+  const rows = aggregateAllLocalSkills(list);
+
+  if (flags.json) {
+    console.log(JSON.stringify({ count: rows.length, items: rows }, null, 2));
+    return;
+  }
+  if (rows.length === 0) {
+    console.log('No local skills found.');
+    return;
+  }
+
+  printTable(rows, [
+    { label: 'NAME', get: (row) => row.name, min: 12, max: 34 },
+    { label: 'TYPE', get: (row) => row.type, min: 7, max: 9 },
+    { label: 'AGENTS', get: (row) => row.agents.join(','), min: 10, max: 30 },
+    { label: 'FORMATS', get: (row) => row.formats.join(','), min: 10, max: 24 },
+    { label: 'COPIES', get: (row) => row.copies, min: 6, max: 6 },
+    { label: 'TAG', get: (row) => formatTagForDisplay(row.tag), min: 8, max: 10 },
+    { label: 'UPDATED', get: (row) => String(row.updatedAt || '').slice(0, 19), min: 19, max: 19 }
+  ]);
+  console.log(`\nTotal: ${rows.length}`);
+}
+
+function createSkillDetailPayload(registry, item) {
+  const siblings = getRegistryItems(registry)
+    .filter((entry) => entry.id === item.id)
+    .map((entry) => ({
+      key: entry.key,
+      canonicalPath: entry.canonicalPath,
+      sourceName: entry.sourceName,
+      sourceScope: entry.sourceScope,
+      sourceAgent: entry.sourceAgent,
+      sourceFormat: entry.sourceFormat,
+      state: entry.state,
+      tag: entry.policy?.tag || 'regular',
+      isPrimary: Boolean(entry.isPrimary)
+    }));
+
+  return {
+    ...item,
+    copies: siblings
+  };
+}
+
+async function cmdSkillDetail(flags, positionalArgs) {
+  const selector = positionalArgs[0];
+  if (!selector) {
+    throw makeCliError('Usage: skillsdock skill-detail <selector>', 2);
+  }
+
+  const { registry } = await loadRegistry(flags.registry);
+  const matches = resolveSelectorMatches(registry, selector, {
+    allCopies: Boolean(flags['all-copies'] || flags.allCopies),
+    includeDeleted: true
+  });
+  if (matches.length === 0) {
+    throw makeCliError(`Skill not found: ${selector}`, 2);
+  }
+
+  const payload = matches.map((entry) => createSkillDetailPayload(registry, entry));
+  if (flags.json) {
+    console.log(JSON.stringify({ count: payload.length, items: payload }, null, 2));
+    return;
+  }
+
+  for (const [index, detail] of payload.entries()) {
+    if (index > 0) {
+      console.log('\n---');
+    }
+    console.log(`ID: ${detail.id}`);
+    console.log(`Name: ${detail.name}`);
+    console.log(`Tag: ${formatTagForDisplay(detail.policy?.tag)}`);
+    console.log(`State: ${detail.state}`);
+    console.log(`Path: ${detail.canonicalPath}`);
+    console.log(`Source: ${detail.sourceName}`);
+    console.log(`Scope: ${detail.sourceScope || '-'}`);
+    console.log(`Agent: ${detail.sourceAgent || '-'}`);
+    console.log(`Format: ${detail.sourceFormat}`);
+    console.log(`Hash: ${detail.hash || '-'}`);
+    console.log(`Manifest Hash: ${detail.manifestHash || '-'}`);
+    console.log(`Included Files: ${detail.structureManifest?.includedFiles?.length || 0}`);
+    if (Array.isArray(detail.structureManifest?.parseWarnings) && detail.structureManifest.parseWarnings.length > 0) {
+      for (const warning of detail.structureManifest.parseWarnings) {
+        console.log(`WARN: ${warning}`);
+      }
+    }
+    console.log(`Copies: ${detail.copies.length}`);
+  }
+}
+
+function ensureValidTag(tag) {
+  const normalizedTag = String(tag || '');
+  if (!VALID_TAG_SET.has(normalizedTag)) {
+    throw makeCliError(`Invalid tag "${normalizedTag}". Use regular|disabled|frozen|deleted.`, 2);
+  }
+  return normalizedTag;
+}
+
+async function cmdTag(flags, positionalArgs) {
+  const action = positionalArgs[0];
+  if (!action) {
+    throw makeCliError('Usage: skillsdock tag <set|list> ...', 2);
+  }
+
+  if (action === 'set') {
+    const selector = positionalArgs[1];
+    if (!selector) {
+      throw makeCliError('Usage: skillsdock tag set <selector> --tag <regular|disabled|frozen|deleted>', 2);
+    }
+    const tag = ensureValidTag(flags.tag);
+    const reason = String(flags.reason || '');
+    const allowAllCopies = Boolean(flags['all-copies'] || flags.allCopies);
+    const { registryPath, registry } = await loadRegistry(flags.registry);
+    const matches = resolveSelectorMatches(registry, selector, {
+      allCopies: allowAllCopies,
+      includeDeleted: true
+    });
+    if (matches.length === 0) {
+      throw makeCliError(`Skill not found: ${selector}`, 2);
+    }
+
+    const now = new Date().toISOString();
+    for (const match of matches) {
+      const key = match.key;
+      registry.items[key] = {
+        ...registry.items[key],
+        policy: {
+          tag,
+          reason,
+          updatedAt: now
+        }
+      };
+    }
+    registry.updatedAt = now;
+    rebuildRegistryIndexes(registry);
+    await writeJson(registryPath, registry);
+    console.log(`Updated tag for ${matches.length} skill(s) to ${tag}`);
+    return;
+  }
+
+  if (action === 'list') {
+    const { registry } = await loadRegistry(flags.registry);
+    const list = filterBySharedFlags(getRegistryItems(registry), flags).sort((a, b) =>
+      (a.id || '').localeCompare(b.id || '')
+    );
+
+    if (flags.json) {
+      console.log(JSON.stringify({ count: list.length, items: list }, null, 2));
+      return;
+    }
+    if (list.length === 0) {
+      console.log('No tagged skills found.');
+      return;
+    }
+    printTable(list, [
+      { label: 'ID', get: (row) => row.id, min: 12, max: 34 },
+      { label: 'TAG', get: (row) => formatTagForDisplay(row.policy?.tag), min: 8, max: 10 },
+      { label: 'SOURCE', get: (row) => row.sourceName, min: 8, max: 22 },
+      { label: 'SCOPE', get: (row) => row.sourceScope || '-', min: 7, max: 7 },
+      { label: 'UPDATED', get: (row) => String(row.policy?.updatedAt || '').slice(0, 19), min: 19, max: 19 }
+    ]);
+    console.log(`\nTotal: ${list.length}`);
+    return;
+  }
+
+  throw makeCliError(`Unknown tag action: ${action}. Use set|list.`, 2);
+}
+
+function compareCleanupKeeper(a, b) {
+  const tagDiff = (TAG_PRIORITY[b.policy?.tag || 'regular'] || 0) - (TAG_PRIORITY[a.policy?.tag || 'regular'] || 0);
+  if (tagDiff !== 0) return tagDiff;
+
+  const scopeOrder = { project: 3, user: 2 };
+  const scopeDiff = (scopeOrder[b.sourceScope] || 1) - (scopeOrder[a.sourceScope] || 1);
+  if (scopeDiff !== 0) return scopeDiff;
+
+  if (Boolean(a.isPrimary) !== Boolean(b.isPrimary)) {
+    return a.isPrimary ? -1 : 1;
+  }
+
+  const updatedDiff = toTimestampForSort(b.updatedAt) - toTimestampForSort(a.updatedAt);
+  if (updatedDiff !== 0) return updatedDiff;
+
+  return String(a.canonicalPath || '').localeCompare(String(b.canonicalPath || ''));
+}
+
+function buildCleanupPlan(registry, flags) {
+  const baseItems = filterBySharedFlags(getRegistryItems(registry), flags);
+  const items = baseItems.filter((item) => (flags.all ? true : !isDeleted(item)));
+  const issues = [];
+  const actions = [];
+
+  const orphaned = items.filter((item) => !fsSync.existsSync(item.canonicalPath || item.sourcePath || ''));
+  for (const item of orphaned) {
+    issues.push({
+      type: 'orphaned_record',
+      key: item.key,
+      id: item.id,
+      canonicalPath: item.canonicalPath
+    });
+    if (!isFrozen(item) && !isDeleted(item)) {
+      actions.push({
+        key: item.key,
+        toTag: 'deleted',
+        reason: `cleanup:orphaned:${item.canonicalPath}`
+      });
+    }
+  }
+
+  const byManifestHash = new Map();
+  for (const item of items) {
+    const manifestHash = item.manifestHash || item.hash;
+    if (!manifestHash) continue;
+    if (!byManifestHash.has(manifestHash)) byManifestHash.set(manifestHash, []);
+    byManifestHash.get(manifestHash).push(item);
+  }
+  for (const [manifestHash, group] of byManifestHash.entries()) {
+    if (group.length < 2) continue;
+    const sorted = [...group].sort(compareCleanupKeeper);
+    const keeper = sorted[0];
+    issues.push({
+      type: 'exact_duplicate',
+      manifestHash,
+      keeperKey: keeper.key,
+      keys: sorted.map((entry) => entry.key)
+    });
+    for (const entry of sorted.slice(1)) {
+      if (isFrozen(entry)) continue;
+      if (hasTag(entry, 'disabled')) continue;
+      actions.push({
+        key: entry.key,
+        toTag: 'disabled',
+        reason: `cleanup:duplicate-of:${keeper.key}`
+      });
+    }
+  }
+
+  const byGroup = new Map();
+  for (const item of items) {
+    const groupKey = String(item.normalized?.name || item.id || '').trim().toLowerCase();
+    if (!groupKey) continue;
+    if (!byGroup.has(groupKey)) byGroup.set(groupKey, []);
+    byGroup.get(groupKey).push(item);
+  }
+  for (const [groupKey, group] of byGroup.entries()) {
+    const uniqueHashes = toArrayUnique(group.map((entry) => entry.manifestHash || entry.hash).filter(Boolean));
+    if (uniqueHashes.length <= 1) continue;
+    issues.push({
+      type: 'name_collision',
+      groupKey,
+      hashes: uniqueHashes,
+      keys: group.map((entry) => entry.key)
+    });
+  }
+
+  const byId = new Map();
+  for (const item of items) {
+    if (!byId.has(item.id)) byId.set(item.id, []);
+    byId.get(item.id).push(item);
+  }
+  for (const [id, group] of byId.entries()) {
+    const scopes = new Set(group.map((entry) => entry.sourceScope).filter(Boolean));
+    if (!(scopes.has('user') && scopes.has('project'))) continue;
+    const uniqueHashes = toArrayUnique(group.map((entry) => entry.manifestHash || entry.hash).filter(Boolean));
+    if (uniqueHashes.length <= 1) continue;
+    issues.push({
+      type: 'shadowing_conflict',
+      id,
+      keys: group.map((entry) => entry.key),
+      hashes: uniqueHashes
+    });
+  }
+
+  const actionMap = new Map();
+  for (const action of actions) {
+    if (!actionMap.has(action.key)) {
+      actionMap.set(action.key, action);
+    }
+  }
+
+  return {
+    items,
+    issues,
+    actions: [...actionMap.values()]
+  };
+}
+
+function createCleanupRunId() {
+  return `cln-${new Date().toISOString().replace(/[:.]/g, '').replace(/-/g, '')}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+}
+
+async function cmdCleanup(flags) {
+  const { registryPath, registry } = await loadRegistry(flags.registry);
+  const rollbackRunId = typeof flags.rollback === 'string' ? flags.rollback : null;
+
+  if (rollbackRunId) {
+    const entry = (registry.cleanupHistory || []).find((row) => row.runId === rollbackRunId);
+    if (!entry) {
+      throw makeCliError(`Cleanup run not found: ${rollbackRunId}`, 2);
+    }
+    let restored = 0;
+    let failed = 0;
+    for (const action of entry.actions || []) {
+      const item = registry.items[action.key];
+      if (!item) {
+        failed += 1;
+        continue;
+      }
+      registry.items[action.key] = {
+        ...item,
+        policy: {
+          tag: action.beforeTag,
+          reason: action.beforeReason || '',
+          updatedAt: new Date().toISOString()
+        }
+      };
+      restored += 1;
+    }
+    registry.updatedAt = new Date().toISOString();
+    rebuildRegistryIndexes(registry);
+    await writeJson(registryPath, registry);
+    console.log(`Rollback ${rollbackRunId}: restored=${restored} failed=${failed}`);
+    if (failed > 0) process.exitCode = 1;
+    return;
+  }
+
+  const modePlan = Boolean(flags.plan);
+  const modeApply = Boolean(flags.apply);
+  if (modePlan === modeApply) {
+    throw makeCliError('Usage: skillsdock cleanup --plan|--apply', 2);
+  }
+
+  const plan = buildCleanupPlan(registry, flags);
+  if (modePlan) {
+    if (flags.json) {
+      console.log(JSON.stringify(plan, null, 2));
+      return;
+    }
+    console.log(`Cleanup plan: issues=${plan.issues.length} actions=${plan.actions.length}`);
+    if (plan.actions.length > 0) {
+      printTable(plan.actions, [
+        { label: 'KEY', get: (row) => row.key, min: 18, max: 42 },
+        { label: 'TAG', get: (row) => row.toTag, min: 8, max: 10 },
+        { label: 'REASON', get: (row) => row.reason, min: 16, max: 70 }
+      ]);
+    }
+    return;
+  }
+
+  const runId = createCleanupRunId();
+  const now = new Date().toISOString();
+  const historyActions = [];
+  let applied = 0;
+  let failed = 0;
+  for (const action of plan.actions) {
+    const item = registry.items[action.key];
+    if (!item) {
+      failed += 1;
+      continue;
+    }
+    if (isFrozen(item)) {
+      continue;
+    }
+    const beforeTag = item.policy?.tag || 'regular';
+    const beforeReason = item.policy?.reason || '';
+    registry.items[action.key] = {
+      ...item,
+      policy: {
+        tag: action.toTag,
+        reason: action.reason,
+        updatedAt: now
+      }
+    };
+    historyActions.push({
+      key: action.key,
+      beforeTag,
+      beforeReason,
+      afterTag: action.toTag,
+      afterReason: action.reason
+    });
+    applied += 1;
+  }
+
+  if (!Array.isArray(registry.cleanupHistory)) {
+    registry.cleanupHistory = [];
+  }
+  registry.cleanupHistory.push({
+    runId,
+    createdAt: now,
+    actions: historyActions
+  });
+  registry.updatedAt = now;
+  rebuildRegistryIndexes(registry);
+  await writeJson(registryPath, registry);
+
+  console.log(`Cleanup apply: runId=${runId} applied=${applied} failed=${failed} issues=${plan.issues.length}`);
+  if (failed > 0) process.exitCode = 1;
 }
 
 function getTargetFilePath(basePath, targetConfig, item) {
@@ -1136,8 +2470,9 @@ async function cmdSync(flags, context) {
   }
 
   const dryRun = Boolean(flags['dry-run'] || flags.dryRun);
-  const items = Object.values(registry.items || {})
+  const items = getRegistryItems(registry)
     .filter((item) => item.state === 'active')
+    .filter((item) => isSyncEligible(item))
     .filter((item) => (flags.all ? true : item.isPrimary))
     .sort((a, b) => a.id.localeCompare(b.id));
 
@@ -1317,6 +2652,73 @@ async function cmdDoctorAgents(config, context) {
   ]);
 }
 
+function validateSkillNameAgainstSpec(name) {
+  if (typeof name !== 'string') {
+    return 'frontmatter name must be a string';
+  }
+  const normalized = name.trim();
+  if (!normalized) {
+    return 'frontmatter name must be non-empty';
+  }
+  if (normalized.length > 64) {
+    return `frontmatter name exceeds 64 chars: ${normalized.length}`;
+  }
+  if (!SKILL_NAME_SPEC_REGEX.test(normalized)) {
+    return `frontmatter name should match ${SKILL_NAME_SPEC_REGEX} (recommended lowercase + hyphen style)`;
+  }
+  return null;
+}
+
+async function collectSkillsSpecDiagnostics(config, context) {
+  const issues = [];
+  const notes = [];
+  const projectRoot = context.projectRoot;
+  let checkedCount = 0;
+
+  for (const source of config.sources || []) {
+    const sourcePath = resolveTemplatePath(source.path, { projectRoot });
+    if (!fsSync.existsSync(sourcePath)) continue;
+
+    const sourceFormat = normalizeSourceFormat(source.format, source.path);
+    if (sourceFormat !== 'skill-md') continue;
+
+    const pluginDiscovery = await getPluginSkillSearchResult(sourcePath);
+    for (const warning of pluginDiscovery.warnings) {
+      issues.push(`skills-spec (${source.name}): ${warning}`);
+    }
+
+    const skillFiles = await collectSkillFiles(
+      sourcePath,
+      sourceFormat,
+      config.scan.maxDepth,
+      config.scan.ignoreDirs
+    );
+
+    for (const filePath of skillFiles) {
+      let parsed;
+      try {
+        parsed = await parseSkillRecord(filePath, source, sourcePath, sourceFormat, config.scan);
+      } catch (error) {
+        issues.push(
+          `skills-spec (${source.name}): failed to parse ${filePath}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+        continue;
+      }
+
+      checkedCount += 1;
+      const nameIssue = validateSkillNameAgainstSpec(parsed.metadata?.name);
+      if (nameIssue) {
+        issues.push(`skills-spec (${source.name}): ${filePath}: ${nameIssue}`);
+      }
+    }
+  }
+
+  notes.push(`Skills spec checked files: ${checkedCount}`);
+  return { issues, notes };
+}
+
 async function cmdDoctor(flags, context) {
   const projectRoot = context.projectRoot;
   const { configPath, config } = await loadConfig(flags.config, projectRoot);
@@ -1337,6 +2739,18 @@ async function cmdDoctor(flags, context) {
     notes.push(`Registry: ${registryPath}`);
     notes.push(`Last scan: ${registry.lastScanAt || 'never'}`);
     notes.push(`Items: ${Object.keys(registry.items || {}).length}`);
+
+    const byCanonicalPath = registry.index?.byCanonicalPath || {};
+    for (const [canonicalPath, key] of Object.entries(byCanonicalPath)) {
+      const item = registry.items?.[key];
+      if (!item) {
+        issues.push(`Registry index mismatch: missing item for canonical path ${canonicalPath}`);
+        continue;
+      }
+      if (item.canonicalPath !== canonicalPath) {
+        issues.push(`Registry index mismatch: key ${key} points to unexpected canonical path`);
+      }
+    }
   }
 
   for (const source of config.sources || []) {
@@ -1364,6 +2778,12 @@ async function cmdDoctor(flags, context) {
 
   if (flags.agents) {
     await cmdDoctorAgents(config, context);
+  }
+  if (flags['skills-spec'] || flags.skillsSpec) {
+    const skillsSpec = await collectSkillsSpecDiagnostics(config, context);
+    for (const line of skillsSpec.notes) console.log(`OK: ${line}`);
+    for (const line of skillsSpec.issues) console.log(`WARN: ${line}`);
+    issues.push(...skillsSpec.issues);
   }
 
   if (issues.length === 0) {
@@ -1401,6 +2821,22 @@ export async function runCli(argv = process.argv.slice(2), options = {}) {
     await cmdScan(flags, args, context);
     return;
   }
+  if (command === 'all-local-skills') {
+    await cmdAllLocalSkills(flags);
+    return;
+  }
+  if (command === 'skill-detail') {
+    await cmdSkillDetail(flags, args);
+    return;
+  }
+  if (command === 'tag') {
+    await cmdTag(flags, args);
+    return;
+  }
+  if (command === 'cleanup') {
+    await cmdCleanup(flags);
+    return;
+  }
   if (command === 'list') {
     await cmdList(flags);
     return;
@@ -1425,11 +2861,14 @@ export {
   AGENT_REGISTRY,
   APP_VERSION,
   buildDefaultConfig,
+  buildCleanupPlan,
   convertContentToFormat,
   detectProjectRoot,
+  normalizeRegistry,
   normalizeConfigV2,
   parseContentForFormat,
   planSyncWriteMode,
+  resolveSelectorMatches,
   resolveSyncTarget,
   resolveTemplatePath
 };

--- a/bin/skillsdock.mjs
+++ b/bin/skillsdock.mjs
@@ -4,5 +4,7 @@ import { runCli } from './skillsdock-core.mjs';
 
 runCli().catch((error) => {
   console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
-  process.exit(1);
+  const exitCode =
+    error && typeof error === 'object' && typeof error.exitCode === 'number' ? error.exitCode : 1;
+  process.exit(exitCode);
 });

--- a/docs/v0.1.2-plan.md
+++ b/docs/v0.1.2-plan.md
@@ -1,0 +1,193 @@
+# SkillsDock v0.1.2 Plan
+
+Last updated: 2026-02-24
+
+## 1) Version Goal
+
+v0.1.2 only focuses on one thing: local skill governance.
+
+Product promise:
+- Manage scattered skills in one place.
+- Organize and clean with clear, safe actions.
+- Keep sync behavior predictable after cleanup.
+
+## 2) Product Decisions Locked
+
+1. List view should not default to absolute paths.
+- First-level view shows key summary fields.
+- Absolute paths appear in detail view and JSON output.
+
+2. No moved-path tracking in v0.1.2.
+- If path changes, treat as a new record + old record lifecycle handling.
+- Reason: low confidence matching adds complexity and false positives.
+
+3. User-facing naming in v0.1.2:
+- `all local skills / 全部本地技能`
+- `cleanup / 清洁整理大师`
+- `skill tags / 技能标签`
+
+## 3) Scope (Exactly 5 Features)
+
+### 3.1 All Local Skills (`all-local-skills`)
+
+User value:
+- See all installed local skills across agent paths in one unified view.
+
+CLI:
+- `skillsdock all-local-skills`
+- `skillsdock all-local-skills --json`
+- `skillsdock all-local-skills --source <name> --scope <user|project>`
+- `skillsdock skill-detail <key|path>`
+
+First-level list fields (no absolute path):
+- `name` (skill display name)
+- `type` (`global` | `project` | `mixed`)
+- `formats` (e.g. `skill-md`, `mdc`)
+- `agents` (derived from source/target mapping)
+- `copies` (number of local variants)
+- `tag` (regular/disabled/frozen/deleted)
+- `updatedAt`
+
+Detail fields (full info):
+- canonical absolute path
+- source name/path/format/scope/agent
+- normalized metadata (`name`, `description`)
+- content hash
+- tag + reason
+- related copies and primary selection
+- structure manifest summary (from feature 5)
+
+Implementation:
+- Reuse registry items, add an aggregation layer by logical skill group.
+- Keep existing `list`/`inspect` compatible; `all-local-skills` is governance-oriented output.
+
+### 3.2 Skill Tags (`tag`)
+
+User value:
+- Mark lifecycle and enforcement policy directly on skills.
+
+Tag set (v0.1.2):
+- `regular` = 常规
+- `disabled` = 禁用
+- `frozen` = 固化
+- `deleted` = 删除
+
+CLI:
+- `skillsdock tag set <key|path|id> --tag <regular|disabled|frozen|deleted> [--reason "..."]`
+- `skillsdock tag list [--tag ...] [--json]`
+
+Behavior contract:
+- `regular`: normal scan/list/sync/cleanup behavior
+- `disabled`: visible in list, excluded from sync by default
+- `frozen`: Dock does not mutate content-derived registry fields during scan
+- `deleted`: soft-deleted tombstone; hidden from default list and excluded from sync
+
+Implementation:
+- Add `policy.tag`, `policy.reason`, `policy.updatedAt` to each registry item.
+- Centralize policy check in shared helpers used by `scan`, `list`, `sync`, `cleanup`.
+
+### 3.3 Cleanup (`cleanup`)
+
+User value:
+- One command to find redundancy/conflicts and apply safe cleanup actions.
+
+CLI:
+- `skillsdock cleanup --plan`
+- `skillsdock cleanup --apply`
+- `skillsdock cleanup --rollback <runId>`
+- `skillsdock cleanup --plan --json`
+
+Detection rules (v0.1.2):
+- exact duplicate: same normalized hash across multiple locations
+- name collision: same normalized name/id but different hash
+- shadowing conflict: same logical skill exists in both user+project scopes
+- orphaned record: registry item points to missing path
+
+Action policy (safe-first):
+- Default actions modify tags only (`disabled` or `deleted`)
+- No physical source file deletion in v0.1.2
+- Every apply writes history for rollback
+
+Implementation:
+- Add `cleanupHistory` (run metadata + per-item before/after states) to registry.
+- `--plan` is pure read, `--apply` is explicit write.
+
+### 3.4 Canonical Path as Source of Truth
+
+User value:
+- Reliable identity for local governance without relying on unstable display ids.
+
+Rules:
+- Canonical absolute path is the record truth key.
+- Existing `id` remains a grouping/search key, not uniqueness key.
+- All write operations (`tag`, `cleanup apply`, future sync policy writes) resolve to canonical path records.
+
+Implementation:
+- Normalize with `resolveTemplatePath` + `path.resolve` and store canonical path field.
+- Registry key strategy:
+  - keep backward compatibility with existing key format
+  - add canonical path index for lookups and future migration safety
+- No moved-path auto-linking in v0.1.2.
+
+### 3.5 Skill Structure Parsing (Spec-driven, Not Guessed)
+
+User value:
+- Correctly manage multi-file skills instead of treating everything as single-file text.
+
+Official references for v0.1.2 parser rules:
+- Vercel skills reference implementation: [vercel-labs/skills](https://github.com/vercel-labs/skills)
+- Claude Agent Skills docs: [docs.claude.com/en/docs/claude-code/skills](https://docs.claude.com/en/docs/claude-code/skills)
+- OpenClaw skills docs: [docs.openclaw.ai/tools/skills](https://docs.openclaw.ai/tools/skills)
+- OpenCode skills docs: [opencode.ai/docs/skills](https://opencode.ai/docs/skills)
+- Cursor rules docs (MDC): [docs.cursor.com/en/context](https://docs.cursor.com/en/context)
+
+v0.1.2 parser baseline:
+- `skill-md`: parse skill folder as a unit with required `SKILL.md` plus optional supporting files
+- `openclaw-md`: parse skill folder with `SKILL.md` as entry
+- `opencode-md`: parse skill folder with `SKILL.md` as entry
+- `mdc`: single-file rule parsing (`*.mdc`) in this version
+
+For each skill record, store `structureManifest`:
+- `entryFile`
+- `rootDir`
+- `includedFiles[]` (relative paths)
+- `fileHashes[]` (or per-file hash map)
+- `parseWarnings[]`
+
+Use in v0.1.2:
+- cleanup duplicate/conflict decisions can use whole-skill manifest hash, not only entry file
+- detail view can show a compact file tree summary
+
+## 4) Out of Scope (v0.1.2)
+
+- moved-path tracking heuristics
+- automatic file deletion on disk
+- remote registry/marketplace integration
+- private tag and distribution policy
+
+## 5) Data Compatibility
+
+- Keep config schema at version 2 in v0.1.2.
+- Registry migration must be non-destructive:
+  - backfill missing `policy` fields with defaults
+  - backfill canonical path index
+  - preserve old keys and metadata
+
+## 6) Acceptance Criteria
+
+1. User can view all local skills in one command with concise first-level output.
+2. User can set and persist tags, and tags affect scan/sync/cleanup behavior deterministically.
+3. User can run `cleanup --plan`, then `cleanup --apply`, and rollback by `runId`.
+4. Path-based lookup is stable; commands work by key/path even when display ids collide.
+5. Multi-file skill manifests are produced for supported formats and used in cleanup decisions.
+
+## 7) Test Plan Additions
+
+- tag behavior tests: `regular/disabled/frozen/deleted`
+- cleanup plan/apply/rollback tests
+- canonical path lookup tests
+- structure parser tests for:
+  - folder-based skill with supporting files
+  - mdc single-file rule
+- smoke flow update:
+  - `init -> scan -> all-local-skills -> tag set -> cleanup --plan -> sync --dry-run -> doctor`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cogineai/skillsdock",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "CLI to scan, track, and sync AI skills across agents and IDEs.",
   "bin": {
     "skillsdock": "bin/skillsdock.mjs"
@@ -45,6 +45,7 @@
     "node": ">=18.17.0"
   },
   "dependencies": {
+    "gray-matter": "^4.0.3",
     "jszip": "^3.10.1"
   }
 }

--- a/test/format-adapter.test.mjs
+++ b/test/format-adapter.test.mjs
@@ -12,6 +12,21 @@ test('parseContentForFormat parses skill markdown frontmatter', () => {
   assert.match(parsed.normalized.body, /Run steps\./);
 });
 
+test('parseContentForFormat rejects skill-md without required frontmatter', () => {
+  assert.throws(
+    () => parseContentForFormat('skill-md', '# Missing frontmatter', '/tmp/invalid/SKILL.md'),
+    /missing YAML frontmatter/
+  );
+});
+
+test('parseContentForFormat rejects skill-md with non-string name/description', () => {
+  const raw = `---\nname: 123\ndescription: true\n---\n\n# Invalid`;
+  assert.throws(
+    () => parseContentForFormat('skill-md', raw, '/tmp/invalid/SKILL.md'),
+    /must include string "name" and "description"/
+  );
+});
+
 test('convertContentToFormat converts mdc to skill-md', () => {
   const item = {
     sourceFormat: 'mdc',

--- a/test/governance.test.mjs
+++ b/test/governance.test.mjs
@@ -1,0 +1,414 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { normalizeRegistry } from '../bin/skillsdock-core.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'skillsdock.mjs');
+
+function runCli(args, cwd, envOverrides = {}) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...envOverrides
+    }
+  });
+}
+
+test('normalizeRegistry migrates v1 items to canonical path keys and legacy index', () => {
+  const input = {
+    version: 1,
+    items: {
+      'source-a:/tmp/skills/a/SKILL.md': {
+        id: 'a',
+        sourcePath: '/tmp/skills/a/SKILL.md',
+        hash: 'h1',
+        normalized: { name: 'A', description: '', body: '# A' },
+        updatedAt: '2026-01-01T00:00:00.000Z'
+      },
+      'source-b:/tmp/skills/a/SKILL.md': {
+        id: 'a',
+        sourcePath: '/tmp/skills/a/SKILL.md',
+        hash: 'h2',
+        normalized: { name: 'A', description: '', body: '# A2' },
+        updatedAt: '2026-01-02T00:00:00.000Z'
+      }
+    }
+  };
+
+  const registry = normalizeRegistry(input);
+  const canonicalKey = 'path:/tmp/skills/a/SKILL.md';
+
+  assert.equal(registry.version, 2);
+  assert.equal(typeof registry.items[canonicalKey], 'object');
+  assert.equal(registry.index.byCanonicalPath['/tmp/skills/a/SKILL.md'], canonicalKey);
+  assert.equal(
+    registry.index.byLegacyKey['source-a:/tmp/skills/a/SKILL.md'],
+    canonicalKey
+  );
+  assert.equal(
+    registry.index.byLegacyKey['source-b:/tmp/skills/a/SKILL.md'],
+    canonicalKey
+  );
+});
+
+test('governance commands: all-local-skills, tag, cleanup, rollback, sync gating', async () => {
+  const base = await mkdtemp(path.join(tmpdir(), 'skillsdock-governance-'));
+  const sourceA = path.join(base, 'source-a');
+  const sourceB = path.join(base, 'source-b');
+  const targetUserDir = path.join(base, 'target-user');
+  const targetProjectDir = path.join(base, 'target-project');
+  const configPath = path.join(base, 'config.json');
+  const registryPath = path.join(base, 'registry.json');
+
+  await mkdir(path.join(sourceA, 'dup-skill', 'assets'), { recursive: true });
+  await mkdir(path.join(sourceB, 'dup-skill', 'assets'), { recursive: true });
+
+  const skillBody = `---\nname: "Dup Skill"\ndescription: "dup"\n---\n\n# Dup\nhello`;
+  await writeFile(path.join(sourceA, 'dup-skill', 'SKILL.md'), skillBody, 'utf8');
+  await writeFile(path.join(sourceA, 'dup-skill', 'assets', 'extra.md'), 'extra-a', 'utf8');
+  await writeFile(path.join(sourceB, 'dup-skill', 'SKILL.md'), skillBody, 'utf8');
+  await writeFile(path.join(sourceB, 'dup-skill', 'assets', 'extra.md'), 'extra-a', 'utf8');
+
+  let result = runCli(['init', '--config', configPath, '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const cfg = JSON.parse(await readFile(configPath, 'utf8'));
+  cfg.sources = [
+    {
+      name: 'fixture-user-a',
+      agent: 'fixture',
+      scope: 'user',
+      path: sourceA,
+      format: 'skill-md',
+      optional: false
+    },
+    {
+      name: 'fixture-project-b',
+      agent: 'fixture',
+      scope: 'project',
+      path: sourceB,
+      format: 'skill-md',
+      optional: false
+    }
+  ];
+  cfg.targets['fixture-user'] = {
+    name: 'fixture-user',
+    agent: 'fixture',
+    scope: 'user',
+    path: targetUserDir,
+    format: 'skill-md',
+    layout: 'nested',
+    filename: 'SKILL.md'
+  };
+  cfg.targets['fixture-project'] = {
+    name: 'fixture-project',
+    agent: 'fixture',
+    scope: 'project',
+    path: targetProjectDir,
+    format: 'skill-md',
+    layout: 'nested',
+    filename: 'SKILL.md'
+  };
+  await writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, 'utf8');
+
+  result = runCli(['scan', sourceA, sourceB, '--config', configPath, '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  result = runCli(['all-local-skills', '--registry', registryPath, '--json'], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const allSkills = JSON.parse(result.stdout);
+  assert.equal(allSkills.count > 0, true);
+  assert.equal(allSkills.items[0].copies >= 2, true);
+
+  result = runCli(['skill-detail', 'dup-skill', '--registry', registryPath], base);
+  assert.equal(result.status, 2, result.stderr || result.stdout);
+
+  result = runCli(['skill-detail', 'dup-skill', '--all-copies', '--registry', registryPath, '--json'], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const details = JSON.parse(result.stdout);
+  assert.equal(details.count >= 2, true);
+  assert.equal(details.items.some((item) => (item.structureManifest?.includedFiles?.length || 0) > 1), true);
+
+  result = runCli(
+    ['tag', 'set', 'dup-skill', '--tag', 'deleted', '--all-copies', '--registry', registryPath],
+    base
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  result = runCli(
+    ['sync', '--to', 'fixture', '--scope', 'user', '--config', configPath, '--registry', registryPath, '--dry-run'],
+    base
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Dry run: 0 file\(s\)/);
+
+  result = runCli(
+    ['tag', 'set', 'dup-skill', '--tag', 'regular', '--all-copies', '--registry', registryPath],
+    base
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  result = runCli(['cleanup', '--plan', '--registry', registryPath, '--json'], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const cleanupPlan = JSON.parse(result.stdout);
+  assert.equal(Array.isArray(cleanupPlan.issues), true);
+  assert.equal(Array.isArray(cleanupPlan.actions), true);
+  assert.equal(cleanupPlan.issues.some((issue) => issue.type === 'exact_duplicate'), true);
+
+  result = runCli(['cleanup', '--apply', '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const runIdMatch = result.stdout.match(/runId=([^\s]+)/);
+  assert.equal(Boolean(runIdMatch), true);
+  const runId = runIdMatch[1];
+
+  result = runCli(['tag', 'list', '--registry', registryPath, '--json', '--all'], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const tagsAfterApply = JSON.parse(result.stdout);
+  assert.equal(tagsAfterApply.items.some((item) => item.policy?.tag === 'disabled'), true);
+
+  result = runCli(['cleanup', '--rollback', runId, '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  result = runCli(['tag', 'list', '--registry', registryPath, '--json', '--all'], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const tagsAfterRollback = JSON.parse(result.stdout);
+  assert.equal(tagsAfterRollback.items.some((item) => item.policy?.tag === 'disabled'), false);
+});
+
+test('scan enforces skill-md frontmatter and skips internal skills by default', async () => {
+  const base = await mkdtemp(path.join(tmpdir(), 'skillsdock-parse-align-'));
+  const sourceDir = path.join(base, 'source');
+  const configPath = path.join(base, 'config.json');
+  const registryPath = path.join(base, 'registry.json');
+
+  await mkdir(path.join(sourceDir, 'public-skill'), { recursive: true });
+  await mkdir(path.join(sourceDir, 'internal-skill'), { recursive: true });
+  await mkdir(path.join(sourceDir, 'invalid-skill'), { recursive: true });
+
+  await writeFile(
+    path.join(sourceDir, 'public-skill', 'SKILL.md'),
+    `---\nname: public-skill\ndescription: Public skill\n---\n\n# Public`,
+    'utf8'
+  );
+  await writeFile(
+    path.join(sourceDir, 'internal-skill', 'SKILL.md'),
+    `---\nname: internal-skill\ndescription: Internal skill\nmetadata:\n  internal: true\n---\n\n# Internal`,
+    'utf8'
+  );
+  await writeFile(path.join(sourceDir, 'invalid-skill', 'SKILL.md'), `# Missing frontmatter`, 'utf8');
+
+  let result = runCli(['init', '--config', configPath, '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const cfg = JSON.parse(await readFile(configPath, 'utf8'));
+  cfg.sources = [
+    {
+      name: 'fixture-user',
+      agent: 'fixture',
+      scope: 'user',
+      path: sourceDir,
+      format: 'skill-md',
+      optional: false
+    }
+  ];
+  await writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, 'utf8');
+
+  result = runCli(['scan', sourceDir, '--config', configPath, '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Skipped internal skills: 1/);
+  assert.match(result.stdout, /Parse errors: 1/);
+
+  result = runCli(['all-local-skills', '--registry', registryPath, '--json'], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  let payload = JSON.parse(result.stdout);
+  assert.equal(payload.count, 1);
+  assert.equal(payload.items[0].name, 'public-skill');
+
+  result = runCli(
+    ['scan', sourceDir, '--config', configPath, '--registry', registryPath],
+    base,
+    { INSTALL_INTERNAL_SKILLS: '1' }
+  );
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  result = runCli(['all-local-skills', '--registry', registryPath, '--json'], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  payload = JSON.parse(result.stdout);
+  assert.equal(payload.count, 2);
+  const names = payload.items.map((item) => item.name).sort((a, b) => a.localeCompare(b));
+  assert.deepEqual(names, ['internal-skill', 'public-skill']);
+});
+
+test('scan discovers deep skills declared in .claude-plugin marketplace manifest', async () => {
+  const base = await mkdtemp(path.join(tmpdir(), 'skillsdock-plugin-discovery-'));
+  const sourceDir = path.join(base, 'source');
+  const configPath = path.join(base, 'config.json');
+  const registryPath = path.join(base, 'registry.json');
+
+  await mkdir(path.join(sourceDir, '.claude-plugin'), { recursive: true });
+  await mkdir(path.join(sourceDir, 'plugins', 'my-plugin', 'skills', 'review'), { recursive: true });
+
+  await writeFile(
+    path.join(sourceDir, '.claude-plugin', 'marketplace.json'),
+    JSON.stringify(
+      {
+        metadata: {
+          pluginRoot: './plugins'
+        },
+        plugins: [
+          {
+            name: 'my-plugin',
+            source: './my-plugin',
+            skills: ['./skills/review']
+          }
+        ]
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+
+  await writeFile(
+    path.join(sourceDir, 'plugins', 'my-plugin', 'skills', 'review', 'SKILL.md'),
+    `---\nname: plugin-review\ndescription: plugin-discovered\n---\n\n# Plugin skill`,
+    'utf8'
+  );
+
+  let result = runCli(['init', '--config', configPath, '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const cfg = JSON.parse(await readFile(configPath, 'utf8'));
+  cfg.sources = [
+    {
+      name: 'fixture-user',
+      agent: 'fixture',
+      scope: 'user',
+      path: sourceDir,
+      format: 'skill-md',
+      optional: false
+    }
+  ];
+  cfg.scan.maxDepth = 1;
+  await writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, 'utf8');
+
+  result = runCli(['scan', sourceDir, '--config', configPath, '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  result = runCli(['all-local-skills', '--registry', registryPath, '--json'], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.count, 1);
+  assert.equal(payload.items[0].name, 'plugin-review');
+});
+
+test('doctor --skills-spec flags non-spec skill names', async () => {
+  const base = await mkdtemp(path.join(tmpdir(), 'skillsdock-doctor-spec-'));
+  const sourceDir = path.join(base, 'source');
+  const configPath = path.join(base, 'config.json');
+  const registryPath = path.join(base, 'registry.json');
+
+  await mkdir(path.join(sourceDir, 'bad-name'), { recursive: true });
+  await writeFile(
+    path.join(sourceDir, 'bad-name', 'SKILL.md'),
+    `---\nname: "Bad Name"\ndescription: "Still parseable"\n---\n\n# Bad`,
+    'utf8'
+  );
+
+  let result = runCli(['init', '--config', configPath, '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const cfg = JSON.parse(await readFile(configPath, 'utf8'));
+  cfg.sources = [
+    {
+      name: 'fixture-user',
+      agent: 'fixture',
+      scope: 'user',
+      path: sourceDir,
+      format: 'skill-md',
+      optional: false
+    }
+  ];
+  await writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, 'utf8');
+
+  result = runCli(['scan', sourceDir, '--config', configPath, '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  result = runCli(
+    ['doctor', '--skills-spec', '--config', configPath, '--registry', registryPath],
+    base
+  );
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.match(result.stdout, /skills-spec/);
+  assert.match(result.stdout, /frontmatter name should match/);
+});
+
+test('doctor --skills-spec validates plugin manifest path safety', async () => {
+  const base = await mkdtemp(path.join(tmpdir(), 'skillsdock-doctor-plugin-'));
+  const sourceDir = path.join(base, 'source');
+  const configPath = path.join(base, 'config.json');
+  const registryPath = path.join(base, 'registry.json');
+
+  await mkdir(path.join(sourceDir, '.claude-plugin'), { recursive: true });
+  await mkdir(path.join(sourceDir, 'skills', 'ok-skill'), { recursive: true });
+  await writeFile(
+    path.join(sourceDir, 'skills', 'ok-skill', 'SKILL.md'),
+    `---\nname: ok-skill\ndescription: ok\n---\n\n# ok`,
+    'utf8'
+  );
+
+  await writeFile(
+    path.join(sourceDir, '.claude-plugin', 'marketplace.json'),
+    JSON.stringify(
+      {
+        metadata: {
+          pluginRoot: '../plugins'
+        },
+        plugins: [
+          {
+            name: 'bad-plugin',
+            source: './bad',
+            skills: ['skills/review']
+          }
+        ]
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+
+  let result = runCli(['init', '--config', configPath, '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const cfg = JSON.parse(await readFile(configPath, 'utf8'));
+  cfg.sources = [
+    {
+      name: 'fixture-user',
+      agent: 'fixture',
+      scope: 'user',
+      path: sourceDir,
+      format: 'skill-md',
+      optional: false
+    }
+  ];
+  await writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, 'utf8');
+
+  result = runCli(
+    ['doctor', '--skills-spec', '--config', configPath, '--registry', registryPath],
+    base
+  );
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.match(result.stdout, /Invalid pluginRoot/);
+  assert.match(result.stdout, /must start with "\.\/"/);
+});

--- a/test/smoke.test.mjs
+++ b/test/smoke.test.mjs
@@ -19,7 +19,7 @@ function runCli(args, cwd) {
   return result;
 }
 
-test('smoke: init -> scan -> list -> inspect -> sync dry-run -> doctor --agents', async () => {
+test('smoke: init -> scan -> all-local-skills -> skill-detail -> tag set -> cleanup plan -> sync dry-run -> doctor --agents', async () => {
   const base = await mkdtemp(path.join(tmpdir(), 'skillsdock-smoke-'));
   const sourceDir = path.join(base, 'source-skills');
   const targetUserDir = path.join(base, 'target-user');
@@ -39,14 +39,16 @@ test('smoke: init -> scan -> list -> inspect -> sync dry-run -> doctor --agents'
   assert.equal(result.status, 0, result.stderr || result.stdout);
 
   const cfg = JSON.parse(await readFile(configPath, 'utf8'));
-  cfg.sources.push({
-    name: 'fixture-user',
-    agent: 'fixture',
-    scope: 'user',
-    path: sourceDir,
-    format: 'skill-md',
-    optional: false
-  });
+  cfg.sources = [
+    {
+      name: 'fixture-user',
+      agent: 'fixture',
+      scope: 'user',
+      path: sourceDir,
+      format: 'skill-md',
+      optional: false
+    }
+  ];
   cfg.targets['fixture-user'] = {
     name: 'fixture-user',
     agent: 'fixture',
@@ -67,16 +69,22 @@ test('smoke: init -> scan -> list -> inspect -> sync dry-run -> doctor --agents'
   };
   await writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, 'utf8');
 
-  result = runCli(['scan', '--config', configPath, '--registry', registryPath], base);
+  result = runCli(['scan', sourceDir, '--config', configPath, '--registry', registryPath], base);
   assert.equal(result.status, 0, result.stderr || result.stdout);
 
-  result = runCli(['list', '--config', configPath, '--registry', registryPath, '--json'], base);
+  result = runCli(['all-local-skills', '--config', configPath, '--registry', registryPath, '--json'], base);
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  const listPayload = JSON.parse(result.stdout);
-  assert.equal(listPayload.count > 0, true);
+  const allLocalPayload = JSON.parse(result.stdout);
+  assert.equal(allLocalPayload.count > 0, true);
 
-  const firstId = listPayload.items[0].id;
-  result = runCli(['inspect', firstId, '--registry', registryPath, '--json'], base);
+  const firstId = allLocalPayload.items[0].items[0].id;
+  result = runCli(['skill-detail', firstId, '--registry', registryPath, '--json'], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  result = runCli(['tag', 'set', firstId, '--tag', 'frozen', '--registry', registryPath], base);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  result = runCli(['cleanup', '--plan', '--registry', registryPath], base);
   assert.equal(result.status, 0, result.stderr || result.stdout);
 
   result = runCli(


### PR DESCRIPTION
## Summary\n- ship v0.1.2 governance workflow for local skills management\n- add all-local-skills/skill-detail/tag/cleanup commands with canonical-path registry v2\n- align skill-md parsing/discovery with vercel-labs/skills conventions\n- add doctor --skills-spec checks (Agent Skills conventions + plugin manifest path safety)\n\n## Validation\n- npm test\n- npm run pack:check\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# v0.1.2 发布说明

* **新功能**
  * 新增技能治理命令：查看全部本地技能、查看技能详情、管理技能标签
  * 引入清理工作流支持（计划、执行、回滚操作）
  * 技能可设置为禁用、冻结或删除状态进行生命周期管理
  * 改进的注册表架构和技能发现机制

* **改进**
  * 同步功能现默认排除禁用和删除的技能
  * 增强的文档和兼容性指南

<!-- end of auto-generated comment: release notes by coderabbit.ai -->