### PR TITLE
docs: simplify AGENTS.md collaboration rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,16 @@ For behavior changes:
 
 ## Git / PR Workflow
 
-- Branch names must use prefix: `codex/...`
+- Branch names should use prefix: `<agent-name>/...`
+- Valid `<agent-name>` values come from the built-in agent registry (`bin/agent-registry.json`), currently:
+  - `openclaw`
+  - `codex`
+  - `claude`
+  - `cursor`
+  - `cline`
+  - `codebuddy`
+  - `trae`
+  - `opencode`
 - Keep commits focused and reviewable.
 - Default PR flow: create branch -> push -> open PR -> stop.
 - Do **not** merge PRs automatically (including `gh pr merge`) unless the user explicitly asks to merge.


### PR DESCRIPTION
## Summary\n- simplify AGENTS.md by removing outdated version/business details\n- keep only collaboration and engineering guardrails\n- retain explicit rule: create PR and stop; do not auto-merge without user request\n\n## Validation\n- docs-only change\n- no runtime behavior changes\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 重写并重组工程指南：将“Project Identity”重命名为“Project Basics”，聚焦工程守则与工作流。
  * 增加“工程守则”和“质量门控”说明，强调非破坏性操作、原子写入与确定性输出。
  * 精简代理注册与支持列表为内置代理名清单，移除过时的运行时/网络与远程市场说明。
  * 明确 Git/PR 流程与分支命名约定，去除冗余技术细则和旧版规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->