### PR TITLE
feat(sync): add node_modules skill sync (incremental diff + lockfile updates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Added
 
+- `sync --from node_modules` — discover and sync skills from `node_modules` packages:
+  - `discoverNodeModuleSkills(projectRoot)` scans `node_modules` (including scoped `@org/pkg` packages) for `SKILL.md` files in package root, `skills/`, and `.agents/skills/` directories
+  - Incremental diff using SHA-256 hash comparison (`computeSkillFolderHash`): unchanged skills are skipped ("up to date"), new/changed skills are installed/updated
+  - Syncs to canonical `.agents/skills/<skill-name>/` directory
+  - Updates `skills-lock.json` with `sourceType: "node_modules"` and package name as `source`
+  - `--dry-run` support: prints planned actions without writing files
+  - `--scope user|project` support (defaults to `project`)
+  - Skips `.bin`, `.cache`, and other non-package directories in `node_modules`
+- Test suite `test/node-modules-sync.test.mjs` covering discovery, scoped packages, incremental skip, hash-change update, dry-run, and lockfile updates
+
 - `parseSource(raw)` — pure-function parser that classifies skill sources: GitHub URL, GitLab URL (including sub-groups), SSH URL, local path, `owner/repo` shorthand, and prefix shorthand (`github:`, `gitlab:`). Returns a structured descriptor with `type`, `owner`, `repo`, `branch`, `subpath`, `skillFilter`, and `raw`.
 - `getOwnerRepo(parsed)` — helper that returns `"owner/repo"` from a parsed source descriptor (for lockfile tracking).
 - `sanitizeSubpath(subpath)` — path-traversal guard that rejects any segment equal to `..`.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ skillsdock cleanup --rollback <runId> [--registry <path>]
 skillsdock list [--config <path>] [--registry <path>] [--source <name>] [--changed] [--all] [--json]
 skillsdock inspect <id|key|path> [--registry <path>] [--json]
 skillsdock sync --to <agent|target> --scope <user|project> [--config <path>] [--registry <path>] [--mode <symlink|copy>] [--fallback <copy|fail>] [--dry-run] [--all]
+skillsdock sync --from node_modules [--scope user|project] [--dry-run]
 skillsdock doctor [--config <path>] [--registry <path>] [--agents] [--skills-spec]
 skillsdock version
 ```
@@ -171,6 +172,37 @@ Behavior:
 - If source and destination already resolve to the same real path, sync is a no-op for that item.
 - Existing broken or circular destination symlinks are replaced safely during sync.
 - Atomic copy writes are used (`tmp` + `rename`).
+
+## Syncing Skills From `node_modules`
+
+SkillsDock can discover and install skills published as npm packages:
+
+```bash
+# discover and sync all skills from node_modules (project scope)
+skillsdock sync --from node_modules
+
+# preview what would be synced without writing files
+skillsdock sync --from node_modules --dry-run
+
+# sync to user scope instead of project
+skillsdock sync --from node_modules --scope user
+```
+
+### How It Works
+
+1. **Discovery**: scans `node_modules` for packages containing `SKILL.md` files. Each package is checked at three locations: package root, `skills/`, and `.agents/skills/`. Scoped packages (`@org/pkg`) are fully supported.
+2. **Incremental diff**: computes a SHA-256 hash of each discovered skill directory and compares it against `skills-lock.json`. Skills with unchanged hashes are skipped.
+3. **Install/Update**: new or changed skills are copied into `.agents/skills/<skill-name>/` and the lockfile is updated with `sourceType: "node_modules"`.
+4. **Lockfile tracking**: each synced skill is recorded in `skills-lock.json` with the npm package name as `source`.
+
+### Output
+
+The command prints a summary showing:
+
+- Total skills discovered
+- Skills skipped (unchanged)
+- Skills installed (new)
+- Skills updated (hash changed)
 
 ## Supported Formats
 

--- a/bin/skillsdock-core.mjs
+++ b/bin/skillsdock-core.mjs
@@ -1873,6 +1873,7 @@ Usage:
   skillsdock list [--config <path>] [--registry <path>] [--source <name>] [--changed] [--all] [--json]
   skillsdock inspect <id|key|path> [--registry <path>] [--json]
   skillsdock sync --to <agent|target> --scope <user|project> [--registry <path>] [--config <path>] [--mode <symlink|copy>] [--fallback <copy|fail>] [--dry-run] [--all]
+  skillsdock sync --from node_modules [--scope user|project] [--dry-run]
   skillsdock doctor [--config <path>] [--registry <path>] [--agents] [--skills-spec]
   skillsdock version
 
@@ -1885,6 +1886,7 @@ Examples:
   skillsdock cleanup --plan
   skillsdock list --changed
   skillsdock sync --to openclaw --scope user --dry-run
+  skillsdock sync --from node_modules --dry-run
 `);
 }
 
@@ -3408,9 +3410,14 @@ async function createSymlink(filePath, sourcePath) {
  * @throws {Error} 当提供了无效的 --mode 或 --fallback 值时抛出。
  */
 async function cmdSync(flags, context) {
+  const fromInput = typeof flags.from === 'string' ? flags.from : undefined;
+  if (fromInput === 'node_modules' || fromInput === 'node-modules') {
+    return cmdSyncFromNodeModules(flags, context);
+  }
+
   const targetInput = flags.to || flags.target;
   if (!targetInput || typeof targetInput !== 'string') {
-    throw new Error('Usage: skillsdock sync --to <agent|target> --scope <user|project>');
+    throw new Error('Usage: skillsdock sync --to <agent|target> --scope <user|project>\n       skillsdock sync --from node_modules [--scope user|project] [--dry-run]');
   }
 
   const projectRoot = context.projectRoot;
@@ -4107,6 +4114,160 @@ async function removeLockfileEntry(projectRoot, skillName) {
   await writeProjectLockfile(projectRoot, lockData);
 }
 
+// ── node_modules skill discovery + sync ─────────────────────────────────
+
+const NODE_MODULES_SKIP_DIRS = new Set(['.bin', '.cache', '.package-lock.json', '.staging', '.yarn-integrity']);
+const NODE_MODULES_SKILL_SEARCH_LOCATIONS = ['', 'skills', '.agents/skills'];
+
+async function discoverNodeModuleSkills(projectRoot) {
+  const nodeModulesDir = path.join(projectRoot, 'node_modules');
+  const results = [];
+
+  let topEntries;
+  try {
+    topEntries = await fs.readdir(nodeModulesDir, { withFileTypes: true });
+  } catch (err) {
+    if (err?.code === 'ENOENT') return results;
+    throw err;
+  }
+
+  const packageDirs = [];
+
+  for (const entry of topEntries) {
+    if (!entry.isDirectory()) continue;
+    if (NODE_MODULES_SKIP_DIRS.has(entry.name)) continue;
+
+    if (entry.name.startsWith('@')) {
+      let scopedEntries;
+      try {
+        scopedEntries = await fs.readdir(path.join(nodeModulesDir, entry.name), { withFileTypes: true });
+      } catch { continue; }
+      for (const sub of scopedEntries) {
+        if (sub.isDirectory()) {
+          packageDirs.push({ packageName: `${entry.name}/${sub.name}`, dir: path.join(nodeModulesDir, entry.name, sub.name) });
+        }
+      }
+    } else {
+      packageDirs.push({ packageName: entry.name, dir: path.join(nodeModulesDir, entry.name) });
+    }
+  }
+
+  for (const { packageName, dir } of packageDirs) {
+    for (const searchLoc of NODE_MODULES_SKILL_SEARCH_LOCATIONS) {
+      const searchDir = searchLoc ? path.join(dir, searchLoc) : dir;
+      const skillMdPath = path.join(searchDir, 'SKILL.md');
+
+      let exists;
+      try {
+        await fs.access(skillMdPath);
+        exists = true;
+      } catch { exists = false; }
+
+      if (!exists) continue;
+
+      const files = [];
+      try {
+        const items = await fs.readdir(searchDir, { withFileTypes: true });
+        for (const item of items) {
+          if (item.isFile()) files.push(item.name);
+        }
+      } catch { continue; }
+
+      const skillName = inferNameFromPath(skillMdPath);
+
+      results.push({
+        packageName,
+        skillName,
+        skillPath: searchDir,
+        files
+      });
+    }
+  }
+
+  return results;
+}
+
+async function cmdSyncFromNodeModules(flags, context) {
+  const projectRoot = context.projectRoot;
+  const dryRun = Boolean(flags['dry-run'] || flags.dryRun);
+  const scope = typeof flags.scope === 'string' ? flags.scope : 'project';
+
+  if (!VALID_SCOPE_SET.has(scope)) {
+    throw new Error(`Invalid --scope value "${scope}". Use --scope user|project.`);
+  }
+
+  const discovered = await discoverNodeModuleSkills(projectRoot);
+
+  if (discovered.length === 0) {
+    console.log('No skills found in node_modules.');
+    return;
+  }
+
+  console.log(`Discovered ${discovered.length} skill(s) in node_modules.`);
+
+  const lockData = await readProjectLockfile(projectRoot);
+
+  const canonicalBase = resolveTemplatePath(getCanonicalSkillsPathTemplate(scope), { projectRoot });
+
+  const counters = { discovered: discovered.length, skipped: 0, installed: 0, updated: 0 };
+  const details = [];
+
+  for (const skill of discovered) {
+    const currentHash = await computeSkillFolderHash(skill.skillPath);
+    const lockEntry = lockData.skills[skill.skillName];
+    const previousHash = lockEntry?.computedHash;
+
+    if (previousHash && previousHash === currentHash) {
+      counters.skipped += 1;
+      details.push({ skillName: skill.skillName, packageName: skill.packageName, action: 'up to date' });
+      continue;
+    }
+
+    const isUpdate = Boolean(previousHash);
+    const destDir = path.join(canonicalBase, skill.skillName);
+
+    if (dryRun) {
+      const action = isUpdate ? 'would update' : 'would install';
+      counters[isUpdate ? 'updated' : 'installed'] += 1;
+      details.push({ skillName: skill.skillName, packageName: skill.packageName, action, dest: destDir });
+      continue;
+    }
+
+    await fs.mkdir(destDir, { recursive: true });
+
+    for (const fileName of skill.files) {
+      const srcFile = path.join(skill.skillPath, fileName);
+      const destFile = path.join(destDir, fileName);
+      const content = await fs.readFile(srcFile, 'utf8');
+      await writeFileAtomic(destFile, content);
+    }
+
+    await updateLockfileEntry(projectRoot, skill.skillName, {
+      source: skill.packageName,
+      sourceType: 'node_modules',
+      computedHash: currentHash,
+      skillPath: path.relative(projectRoot, destDir)
+    });
+
+    const action = isUpdate ? 'updated' : 'installed';
+    counters[action] += 1;
+    details.push({ skillName: skill.skillName, packageName: skill.packageName, action, dest: destDir });
+  }
+
+  if (dryRun) {
+    console.log('\nDry run — no files written.\n');
+  }
+
+  for (const d of details) {
+    const dest = d.dest ? ` -> ${d.dest}` : '';
+    console.log(`  ${d.action}: ${d.skillName} (from ${d.packageName})${dest}`);
+  }
+
+  console.log(
+    `\nSummary: discovered=${counters.discovered} skipped=${counters.skipped} installed=${counters.installed} updated=${counters.updated}`
+  );
+}
+
 export async function runCli(argv = process.argv.slice(2), options = {}) {
   const { flags, positional } = parseArgs(argv);
   const command = positional[0];
@@ -4179,6 +4340,7 @@ export {
   computeSkillFolderHash,
   convertContentToFormat,
   detectProjectRoot,
+  discoverNodeModuleSkills,
   getOwnerRepo,
   normalizeRegistry,
   normalizeConfigV2,

--- a/test/node-modules-sync.test.mjs
+++ b/test/node-modules-sync.test.mjs
@@ -1,0 +1,392 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, readFile, rm, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  discoverNodeModuleSkills,
+  readProjectLockfile,
+  writeProjectLockfile,
+  computeSkillFolderHash,
+  runCli
+} from '../bin/skillsdock-core.mjs';
+
+async function makeTmpDir() {
+  return mkdtemp(path.join(tmpdir(), 'skillsdock-nm-test-'));
+}
+
+async function withTmpDir(fn) {
+  const dir = await makeTmpDir();
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+}
+
+async function createSkillMd(dirPath, skillName, extra = '') {
+  const content = `---
+name: ${skillName}
+description: Test skill ${skillName}
+---
+
+# ${skillName}
+
+Test skill content.
+${extra}`;
+  await writeFile(path.join(dirPath, 'SKILL.md'), content, 'utf8');
+}
+
+async function scaffoldPackageWithSkill(nodeModulesDir, packageName, options = {}) {
+  const { location = '', skillName = null, extraFiles = {} } = options;
+  const pkgDir = path.join(nodeModulesDir, packageName);
+  const skillDir = location ? path.join(pkgDir, location) : pkgDir;
+  await mkdir(skillDir, { recursive: true });
+
+  const name = skillName || packageName.replace(/^@[^/]+\//, '');
+  await createSkillMd(skillDir, name);
+
+  for (const [fileName, content] of Object.entries(extraFiles)) {
+    await writeFile(path.join(skillDir, fileName), content, 'utf8');
+  }
+
+  return { pkgDir, skillDir, skillName: name };
+}
+
+// ── discoverNodeModuleSkills ────────────────────────────────────────────
+
+test('discoverNodeModuleSkills: returns empty when node_modules does not exist', async () => {
+  await withTmpDir(async (dir) => {
+    const results = await discoverNodeModuleSkills(dir);
+    assert.deepStrictEqual(results, []);
+  });
+});
+
+test('discoverNodeModuleSkills: finds SKILL.md at package root', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, 'my-cool-skill');
+
+    const results = await discoverNodeModuleSkills(dir);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].packageName, 'my-cool-skill');
+    assert.equal(results[0].skillName, 'my-cool-skill');
+    assert.ok(results[0].files.includes('SKILL.md'));
+  });
+});
+
+test('discoverNodeModuleSkills: finds SKILL.md in skills/ subdirectory', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, 'pkg-with-skills-dir', { location: 'skills' });
+
+    const results = await discoverNodeModuleSkills(dir);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].packageName, 'pkg-with-skills-dir');
+  });
+});
+
+test('discoverNodeModuleSkills: finds SKILL.md in .agents/skills/ subdirectory', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, 'pkg-with-agents-dir', { location: '.agents/skills' });
+
+    const results = await discoverNodeModuleSkills(dir);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].packageName, 'pkg-with-agents-dir');
+  });
+});
+
+test('discoverNodeModuleSkills: supports scoped packages', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, '@myorg/my-skill');
+
+    const results = await discoverNodeModuleSkills(dir);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].packageName, '@myorg/my-skill');
+    assert.equal(results[0].skillName, 'my-skill');
+  });
+});
+
+test('discoverNodeModuleSkills: skips .bin and .cache directories', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await mkdir(path.join(nmDir, '.bin'), { recursive: true });
+    await mkdir(path.join(nmDir, '.cache'), { recursive: true });
+    await scaffoldPackageWithSkill(nmDir, 'real-skill');
+
+    const results = await discoverNodeModuleSkills(dir);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].packageName, 'real-skill');
+  });
+});
+
+test('discoverNodeModuleSkills: ignores packages without SKILL.md', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    const pkgDir = path.join(nmDir, 'no-skill-pkg');
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(path.join(pkgDir, 'package.json'), '{}', 'utf8');
+
+    const results = await discoverNodeModuleSkills(dir);
+    assert.equal(results.length, 0);
+  });
+});
+
+test('discoverNodeModuleSkills: discovers multiple skills from different packages', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, 'skill-a');
+    await scaffoldPackageWithSkill(nmDir, 'skill-b');
+    await scaffoldPackageWithSkill(nmDir, '@org/skill-c');
+
+    const results = await discoverNodeModuleSkills(dir);
+    assert.equal(results.length, 3);
+    const names = results.map((r) => r.packageName).sort();
+    assert.deepStrictEqual(names, ['@org/skill-c', 'skill-a', 'skill-b']);
+  });
+});
+
+test('discoverNodeModuleSkills: lists all files in skill directory', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, 'multi-file-skill', {
+      extraFiles: { 'helper.md': '# Helper', 'data.json': '{}' }
+    });
+
+    const results = await discoverNodeModuleSkills(dir);
+    assert.equal(results.length, 1);
+    const files = results[0].files.sort();
+    assert.ok(files.includes('SKILL.md'));
+    assert.ok(files.includes('helper.md'));
+    assert.ok(files.includes('data.json'));
+  });
+});
+
+// ── Incremental sync (hash comparison) ──────────────────────────────────
+
+test('sync --from node_modules: incremental skip when hash unchanged', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, 'stable-skill');
+
+    const agentsSkillsDir = path.join(dir, '.agents', 'skills', 'stable-skill');
+    await mkdir(agentsSkillsDir, { recursive: true });
+    await writeFile(path.join(agentsSkillsDir, 'SKILL.md'), 'old content', 'utf8');
+
+    const hash = await computeSkillFolderHash(path.join(nmDir, 'stable-skill'));
+    await writeProjectLockfile(dir, {
+      version: 1,
+      skills: {
+        'stable-skill': {
+          source: 'stable-skill',
+          sourceType: 'node_modules',
+          computedHash: hash,
+          skillPath: '.agents/skills/stable-skill'
+        }
+      }
+    });
+
+    const logs = [];
+    const origLog = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+    try {
+      await runCli(['sync', '--from', 'node_modules', '--scope', 'project'], { cwd: dir });
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join('\n');
+    assert.ok(output.includes('skipped=1'), `Expected skipped=1 in output: ${output}`);
+    assert.ok(output.includes('up to date'), `Expected "up to date" in output: ${output}`);
+  });
+});
+
+test('sync --from node_modules: installs new skill', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, 'new-skill');
+
+    const logs = [];
+    const origLog = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+    try {
+      await runCli(['sync', '--from', 'node_modules', '--scope', 'project'], { cwd: dir });
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join('\n');
+    assert.ok(output.includes('installed=1'), `Expected installed=1 in output: ${output}`);
+
+    const destSkill = path.join(dir, '.agents', 'skills', 'new-skill', 'SKILL.md');
+    const content = await readFile(destSkill, 'utf8');
+    assert.ok(content.includes('new-skill'));
+
+    const lock = await readProjectLockfile(dir);
+    assert.ok(lock.skills['new-skill']);
+    assert.equal(lock.skills['new-skill'].source, 'new-skill');
+    assert.equal(lock.skills['new-skill'].sourceType, 'node_modules');
+    assert.ok(lock.skills['new-skill'].computedHash);
+  });
+});
+
+test('sync --from node_modules: updates skill when hash changes', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, 'changed-skill');
+
+    await writeProjectLockfile(dir, {
+      version: 1,
+      skills: {
+        'changed-skill': {
+          source: 'changed-skill',
+          sourceType: 'node_modules',
+          computedHash: 'old-hash-that-no-longer-matches',
+          skillPath: '.agents/skills/changed-skill'
+        }
+      }
+    });
+
+    const logs = [];
+    const origLog = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+    try {
+      await runCli(['sync', '--from', 'node_modules', '--scope', 'project'], { cwd: dir });
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join('\n');
+    assert.ok(output.includes('updated=1'), `Expected updated=1 in output: ${output}`);
+
+    const lock = await readProjectLockfile(dir);
+    assert.notEqual(lock.skills['changed-skill'].computedHash, 'old-hash-that-no-longer-matches');
+  });
+});
+
+// ── --dry-run ───────────────────────────────────────────────────────────
+
+test('sync --from node_modules --dry-run: does not write files', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, 'dry-skill');
+
+    const logs = [];
+    const origLog = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+    try {
+      await runCli(['sync', '--from', 'node_modules', '--scope', 'project', '--dry-run'], { cwd: dir });
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join('\n');
+    assert.ok(output.includes('Dry run'), `Expected "Dry run" in output: ${output}`);
+    assert.ok(output.includes('would install'), `Expected "would install" in output: ${output}`);
+
+    const destDir = path.join(dir, '.agents', 'skills', 'dry-skill');
+    let exists = false;
+    try {
+      await readdir(destDir);
+      exists = true;
+    } catch {}
+    assert.equal(exists, false, 'dry-run should not create destination directory');
+
+    const lock = await readProjectLockfile(dir);
+    assert.deepStrictEqual(lock.skills, {});
+  });
+});
+
+// ── lockfile update ─────────────────────────────────────────────────────
+
+test('sync --from node_modules: lockfile records correct sourceType', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, '@myorg/tracked-skill');
+
+    const logs = [];
+    const origLog = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+    try {
+      await runCli(['sync', '--from', 'node_modules', '--scope', 'project'], { cwd: dir });
+    } finally {
+      console.log = origLog;
+    }
+
+    const lock = await readProjectLockfile(dir);
+    const entry = lock.skills['tracked-skill'];
+    assert.ok(entry, 'lockfile should contain the skill');
+    assert.equal(entry.source, '@myorg/tracked-skill');
+    assert.equal(entry.sourceType, 'node_modules');
+    assert.ok(entry.computedHash);
+    assert.ok(entry.skillPath);
+  });
+});
+
+test('sync --from node_modules: user scope installs to ~/.agents/skills', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, 'user-scope-skill');
+
+    const logs = [];
+    const origLog = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+    try {
+      await runCli(['sync', '--from', 'node_modules', '--scope', 'user'], { cwd: dir });
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join('\n');
+    assert.ok(output.includes('installed=1'), `Expected installed=1 in output: ${output}`);
+  });
+});
+
+// ── multiple skills at once ─────────────────────────────────────────────
+
+test('sync --from node_modules: handles mixed new, updated, and unchanged skills', async () => {
+  await withTmpDir(async (dir) => {
+    const nmDir = path.join(dir, 'node_modules');
+    await scaffoldPackageWithSkill(nmDir, 'new-one');
+    await scaffoldPackageWithSkill(nmDir, 'up-to-date');
+    await scaffoldPackageWithSkill(nmDir, 'changed-one');
+
+    const upToDateHash = await computeSkillFolderHash(path.join(nmDir, 'up-to-date'));
+
+    await writeProjectLockfile(dir, {
+      version: 1,
+      skills: {
+        'up-to-date': {
+          source: 'up-to-date',
+          sourceType: 'node_modules',
+          computedHash: upToDateHash,
+          skillPath: '.agents/skills/up-to-date'
+        },
+        'changed-one': {
+          source: 'changed-one',
+          sourceType: 'node_modules',
+          computedHash: 'stale-hash-value',
+          skillPath: '.agents/skills/changed-one'
+        }
+      }
+    });
+
+    const logs = [];
+    const origLog = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+    try {
+      await runCli(['sync', '--from', 'node_modules', '--scope', 'project'], { cwd: dir });
+    } finally {
+      console.log = origLog;
+    }
+
+    const output = logs.join('\n');
+    assert.ok(output.includes('discovered=3'), `Expected discovered=3 in: ${output}`);
+    assert.ok(output.includes('skipped=1'), `Expected skipped=1 in: ${output}`);
+    assert.ok(output.includes('installed=1'), `Expected installed=1 in: ${output}`);
+    assert.ok(output.includes('updated=1'), `Expected updated=1 in: ${output}`);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `sync --from node_modules` command path for discovering and syncing skills from npm packages, with incremental SHA-256 hash comparison to avoid redundant syncs.

Closes #10

## Changes

### Core (`bin/skillsdock-core.mjs`)

- **`discoverNodeModuleSkills(projectRoot)`** — scans `node_modules` (including scoped `@org/pkg` packages) for `SKILL.md` files at three locations per package: root, `skills/`, and `.agents/skills/`. Returns `{ packageName, skillName, skillPath, files[] }` for each discovered skill. Skips `.bin`, `.cache`, and other non-package directories.

- **`cmdSyncFromNodeModules(flags, context)`** — the sync handler for `--from node_modules`:
  - Uses `computeSkillFolderHash()` to compute SHA-256 of each discovered skill directory
  - Compares against `skills-lock.json` entries — unchanged hashes are skipped ("up to date")
  - New/changed skills are copied to `.agents/skills/<skill-name>/` using atomic writes
  - Updates lockfile with `source` = package name, `sourceType` = `"node_modules"`
  - Supports `--scope user|project` (defaults to `project`) and `--dry-run`

- **`cmdSync`** extended to detect `--from node_modules` and delegate to the new handler

- **`printHelp()`** updated with `sync --from node_modules` usage line and example

- **Export** `discoverNodeModuleSkills` added to the public API

### Tests (`test/node-modules-sync.test.mjs`)

14 new tests covering:
- Discovery: empty node_modules, root SKILL.md, `skills/` subdir, `.agents/skills/` subdir
- Scoped package support (`@org/pkg`)
- Skip `.bin`/`.cache` directories
- Packages without SKILL.md ignored
- Multiple packages discovery
- Multi-file skill directory listing
- Incremental skip (hash unchanged)
- New skill install + lockfile update
- Hash change triggers update
- `--dry-run` mode (no files written)
- Lockfile `sourceType` correctness for scoped packages
- User scope support
- Mixed new/updated/unchanged batch

### Documentation

- **CHANGELOG.md** — added entry under Unreleased
- **README.md** — added `sync --from node_modules` section with usage examples and explanation, updated Commands list

## Quality Gates

- `npm test` — 150/150 pass (0 fail)
- `npm run pack:check` — clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e0f8641-53e3-4765-9198-088605920621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e0f8641-53e3-4765-9198-088605920621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增从 npm 包同步技能的功能，支持扫描 `node_modules` 中的 SKILL.md 文件
  * 实现增量同步机制，自动跳过未变更的技能，仅更新新增或变更的内容
  * 添加 `--dry-run` 和 `--scope` CLI 选项，用于预览操作和控制同步范围

* **文档**
  * 更新 README 和 CHANGELOG，记录新的同步功能和使用说明

* **测试**
  * 新增完整的测试套件，覆盖发现、增量同步和锁文件更新场景

<!-- end of auto-generated comment: release notes by coderabbit.ai -->