### PR TITLE
feat(cli): add remove command for skill file cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Added
 
+- `skillsdock remove <selector>` — new command to clean up installed skill files, symlinks, and registry/lockfile entries:
+  - Resolves skills by id, key, or path via `resolveSelectorMatches()`
+  - Deletes canonical skill directories under `.agents/skills/`
+  - Scans and removes symlinks from non-universal agent directories that point to the canonical skill
+  - Sets registry tag to `deleted` and removes lockfile entries
+  - `--scope user|project` — restrict removal to a specific scope
+  - `--all --scope <scope>` — remove all skills in the given scope
+  - `--dry-run` — preview actions without modifying files
+  - `--force` — override `frozen` tag protection
+- Test suite `test/remove-command.test.mjs` covering normal removal, frozen protection, `--force`, `--dry-run`, `--all`, lockfile updates, registry tag updates, project scope, and error handling.
+
 - `parseSource(raw)` — pure-function parser that classifies skill sources: GitHub URL, GitLab URL (including sub-groups), SSH URL, local path, `owner/repo` shorthand, and prefix shorthand (`github:`, `gitlab:`). Returns a structured descriptor with `type`, `owner`, `repo`, `branch`, `subpath`, `skillFilter`, and `raw`.
 - `getOwnerRepo(parsed)` — helper that returns `"owner/repo"` from a parsed source descriptor (for lockfile tracking).
 - `sanitizeSubpath(subpath)` — path-traversal guard that rejects any segment equal to `..`.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ skillsdock cleanup --rollback <runId> [--registry <path>]
 skillsdock list [--config <path>] [--registry <path>] [--source <name>] [--changed] [--all] [--json]
 skillsdock inspect <id|key|path> [--registry <path>] [--json]
 skillsdock sync --to <agent|target> --scope <user|project> [--config <path>] [--registry <path>] [--mode <symlink|copy>] [--fallback <copy|fail>] [--dry-run] [--all]
+skillsdock remove <selector> [--scope <user|project>] [--dry-run] [--force] [--all-copies]
+skillsdock remove --all --scope <user|project> [--dry-run] [--force]
 skillsdock doctor [--config <path>] [--registry <path>] [--agents] [--skills-spec]
 skillsdock version
 ```
@@ -171,6 +173,34 @@ Behavior:
 - If source and destination already resolve to the same real path, sync is a no-op for that item.
 - Existing broken or circular destination symlinks are replaced safely during sync.
 - Atomic copy writes are used (`tmp` + `rename`).
+
+## Remove
+
+`skillsdock remove` cleans up installed skill files, symlinks, and metadata:
+
+```bash
+# remove a single skill by id, key, or path
+skillsdock remove my-skill --scope user
+
+# dry run — preview what would be deleted
+skillsdock remove my-skill --scope user --dry-run
+
+# force remove a frozen skill
+skillsdock remove my-skill --scope user --force
+
+# remove all skills in a scope
+skillsdock remove --all --scope project
+```
+
+Behavior:
+
+- Deletes the canonical skill directory under `.agents/skills/<skill-name>/`.
+- Scans non-universal agent directories and removes symlinks pointing to the canonical skill.
+- Sets the registry tag to `deleted` (soft delete).
+- Removes the skill entry from `skills-lock.json` if present.
+- `frozen` skills are skipped unless `--force` is used.
+- `--dry-run` prints all planned actions without writing to disk.
+- `--all` requires `--scope` and removes every (non-frozen) skill in that scope.
 
 ## Supported Formats
 

--- a/bin/skillsdock-core.mjs
+++ b/bin/skillsdock-core.mjs
@@ -1873,6 +1873,8 @@ Usage:
   skillsdock list [--config <path>] [--registry <path>] [--source <name>] [--changed] [--all] [--json]
   skillsdock inspect <id|key|path> [--registry <path>] [--json]
   skillsdock sync --to <agent|target> --scope <user|project> [--registry <path>] [--config <path>] [--mode <symlink|copy>] [--fallback <copy|fail>] [--dry-run] [--all]
+  skillsdock remove <selector> [--scope <user|project>] [--dry-run] [--force] [--all-copies]
+  skillsdock remove --all --scope <user|project> [--dry-run] [--force]
   skillsdock doctor [--config <path>] [--registry <path>] [--agents] [--skills-spec]
   skillsdock version
 
@@ -4107,6 +4109,259 @@ async function removeLockfileEntry(projectRoot, skillName) {
   await writeProjectLockfile(projectRoot, lockData);
 }
 
+// ── remove command ──────────────────────────────────────────────────────
+
+async function findSymlinksPointingTo(targetRealPath, searchBase) {
+  const found = [];
+  async function walk(dir) {
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) {
+        try {
+          const linkTarget = await fs.readlink(full);
+          const resolved = path.resolve(path.dirname(full), linkTarget);
+          const resolvedReal = (await getRealpathOrNull(resolved)) || resolved;
+          if (resolvedReal === targetRealPath || resolved === targetRealPath) {
+            found.push(full);
+          }
+        } catch {}
+      } else if (entry.isDirectory()) {
+        await walk(full);
+      }
+    }
+  }
+  await walk(searchBase);
+  return found;
+}
+
+function getSkillCanonicalDir(item, scope, projectRoot) {
+  const aliases = getItemSourceAliases(item);
+  const scopeAlias = aliases.find((a) => a.scope === scope) || aliases[0];
+  const effectiveScope = scopeAlias?.scope || scope || 'user';
+  const template = getCanonicalSkillsPathTemplate(effectiveScope);
+  return resolveTemplatePath(template, { projectRoot });
+}
+
+async function collectRemoveTargets(item, scope, projectRoot, homeDir) {
+  const targets = { files: [], symlinks: [] };
+  const canonicalBase = resolveTemplatePath(
+    getCanonicalSkillsPathTemplate(scope),
+    { projectRoot, homeDir }
+  );
+  const skillDir = path.join(canonicalBase, item.id);
+  const skillDirExists = await pathExists(skillDir);
+  if (skillDirExists) {
+    targets.files.push(skillDir);
+  }
+
+  const skillDirReal = skillDirExists ? (await getRealpathOrNull(skillDir)) || skillDir : skillDir;
+
+  for (const agent of AGENT_REGISTRY.agents) {
+    if (isUniversalAgent(agent.id)) continue;
+    const scopeCfg = agent.scopes?.[scope];
+    if (!scopeCfg?.target) continue;
+
+    const agentBase = resolveTemplatePath(scopeCfg.target.path, { projectRoot, homeDir });
+    if (!await pathExists(agentBase)) continue;
+
+    const layout = scopeCfg.target.layout || 'nested';
+    let candidatePath;
+    if (layout === 'flat') {
+      const ext = scopeCfg.target.extension || '.md';
+      candidatePath = path.join(agentBase, `${item.id}${ext}`);
+    } else {
+      const filename = scopeCfg.target.filename || 'SKILL.md';
+      candidatePath = path.join(agentBase, item.id, filename);
+    }
+
+    try {
+      const stat = await fs.lstat(candidatePath);
+      if (stat.isSymbolicLink()) {
+        const linkTarget = await fs.readlink(candidatePath);
+        const resolved = path.resolve(path.dirname(candidatePath), linkTarget);
+        const resolvedReal = (await getRealpathOrNull(resolved)) || resolved;
+        if (resolvedReal === skillDirReal || resolved.startsWith(skillDir)) {
+          targets.symlinks.push(candidatePath);
+        }
+      }
+    } catch {}
+
+    if (layout === 'nested') {
+      const nestedDir = path.join(agentBase, item.id);
+      try {
+        const stat = await fs.lstat(nestedDir);
+        if (stat.isSymbolicLink()) {
+          const linkTarget = await fs.readlink(nestedDir);
+          const resolved = path.resolve(path.dirname(nestedDir), linkTarget);
+          const resolvedReal = (await getRealpathOrNull(resolved)) || resolved;
+          if (resolvedReal === skillDirReal || resolved.startsWith(skillDir)) {
+            targets.symlinks.push(nestedDir);
+          }
+        }
+      } catch {}
+    }
+  }
+
+  return targets;
+}
+
+function isPathUnderBase(targetPath, basePath) {
+  const normalizedTarget = path.resolve(targetPath);
+  const normalizedBase = path.resolve(basePath);
+  return normalizedTarget === normalizedBase || normalizedTarget.startsWith(normalizedBase + path.sep);
+}
+
+async function cmdRemove(flags, args, context) {
+  const isAll = Boolean(flags.all);
+  const dryRun = Boolean(flags['dry-run'] || flags.dryRun);
+  const force = Boolean(flags.force);
+  const scope = typeof flags.scope === 'string' ? flags.scope : undefined;
+
+  if (isAll && !scope) {
+    throw makeCliError('--all requires --scope user|project', 2);
+  }
+  if (!isAll && args.length === 0) {
+    throw makeCliError('Usage: skillsdock remove <selector> [--scope user|project] [--dry-run] [--force]', 2);
+  }
+  if (scope && !VALID_SCOPE_SET.has(scope)) {
+    throw makeCliError(`Invalid --scope "${scope}". Use --scope user|project.`, 2);
+  }
+
+  const projectRoot = context.projectRoot;
+  const homeDir = context.homeDir || HOME;
+  const { registryPath, registry } = await loadRegistry(flags.registry);
+
+  let matches;
+  if (isAll) {
+    const items = getRegistryItems(registry).filter((item) => !isDeleted(item));
+    matches = scope ? items.filter((item) => itemMatchesSourceScope(item, scope)) : items;
+  } else {
+    const selector = args[0];
+    matches = resolveSelectorMatches(registry, selector, {
+      allCopies: Boolean(flags['all-copies'] || flags.allCopies),
+      includeDeleted: false
+    });
+    if (matches.length === 0) {
+      throw makeCliError(`Skill not found: ${selector}`, 2);
+    }
+  }
+
+  const scopesToProcess = scope ? [scope] : ['user', 'project'];
+
+  const counters = { files: 0, symlinks: 0, registryUpdated: 0, lockfileUpdated: 0 };
+  const actions = [];
+  const skipped = [];
+
+  for (const match of matches) {
+    if (isFrozen(match) && !force) {
+      skipped.push({ id: match.id, reason: 'frozen (use --force to override)' });
+      continue;
+    }
+
+    for (const s of scopesToProcess) {
+      const targets = await collectRemoveTargets(match, s, projectRoot, homeDir);
+
+      for (const symlink of targets.symlinks) {
+        actions.push({ type: 'symlink', path: symlink, skill: match.id, scope: s });
+      }
+
+      for (const filePath of targets.files) {
+        const canonicalBase = resolveTemplatePath(
+          getCanonicalSkillsPathTemplate(s),
+          { projectRoot, homeDir }
+        );
+        if (!isPathUnderBase(filePath, canonicalBase)) continue;
+        actions.push({ type: 'file', path: filePath, skill: match.id, scope: s });
+      }
+    }
+
+    actions.push({ type: 'registry', key: match.key, skill: match.id });
+    if (projectRoot) {
+      actions.push({ type: 'lockfile', skill: match.id, projectRoot });
+    }
+  }
+
+  if (dryRun) {
+    console.log('Dry run — the following actions would be performed:');
+    for (const action of actions) {
+      if (action.type === 'symlink') {
+        console.log(`  [delete symlink] ${action.path}`);
+      } else if (action.type === 'file') {
+        console.log(`  [delete dir]     ${action.path}`);
+      } else if (action.type === 'registry') {
+        console.log(`  [tag deleted]    registry key=${action.key}`);
+      } else if (action.type === 'lockfile') {
+        console.log(`  [lockfile]       remove "${action.skill}" from ${PROJECT_LOCKFILE_NAME}`);
+      }
+    }
+    for (const s of skipped) {
+      console.log(`  [skipped]        ${s.id}: ${s.reason}`);
+    }
+    console.log(`\nSummary: ${actions.filter((a) => a.type === 'file').length} dir(s), ${actions.filter((a) => a.type === 'symlink').length} symlink(s), ${actions.filter((a) => a.type === 'registry').length} registry update(s)`);
+    return;
+  }
+
+  for (const action of actions) {
+    if (action.type === 'symlink') {
+      try {
+        await fs.unlink(action.path);
+        counters.symlinks++;
+      } catch (err) {
+        if (err?.code !== 'ENOENT') {
+          console.warn(`Warning: failed to remove symlink ${action.path}: ${err.message}`);
+        }
+      }
+    } else if (action.type === 'file') {
+      try {
+        await fs.rm(action.path, { recursive: true });
+        counters.files++;
+      } catch (err) {
+        if (err?.code !== 'ENOENT') {
+          console.warn(`Warning: failed to remove ${action.path}: ${err.message}`);
+        }
+      }
+    } else if (action.type === 'registry') {
+      const key = action.key;
+      if (registry.items[key]) {
+        const now = new Date().toISOString();
+        registry.items[key] = {
+          ...registry.items[key],
+          policy: { tag: 'deleted', reason: 'removed by skillsdock remove', updatedAt: now }
+        };
+        counters.registryUpdated++;
+      }
+    } else if (action.type === 'lockfile') {
+      try {
+        await removeLockfileEntry(action.projectRoot, action.skill);
+        counters.lockfileUpdated++;
+      } catch (err) {
+        console.warn(`Warning: failed to update lockfile for "${action.skill}": ${err.message}`);
+      }
+    }
+  }
+
+  if (counters.registryUpdated > 0) {
+    const now = new Date().toISOString();
+    registry.updatedAt = now;
+    rebuildRegistryIndexes(registry);
+    await writeJson(registryPath, registry);
+  }
+
+  for (const s of skipped) {
+    console.log(`Skipped: ${s.id} — ${s.reason}`);
+  }
+
+  console.log(
+    `Removed ${counters.files} dir(s), ${counters.symlinks} symlink(s), updated ${counters.registryUpdated} registry entry(ies), updated ${counters.lockfileUpdated} lockfile entry(ies)`
+  );
+}
+
 export async function runCli(argv = process.argv.slice(2), options = {}) {
   const { flags, positional } = parseArgs(argv);
   const command = positional[0];
@@ -4166,6 +4421,10 @@ export async function runCli(argv = process.argv.slice(2), options = {}) {
     await cmdDoctor(flags, context);
     return;
   }
+  if (command === 'remove') {
+    await cmdRemove(flags, args, context);
+    return;
+  }
 
   throw new Error(`Unknown command: ${command}`);
 }
@@ -4176,6 +4435,7 @@ export {
   buildDefaultConfig,
   buildDoctorAgentMatrixRows,
   buildCleanupPlan,
+  cmdRemove,
   computeSkillFolderHash,
   convertContentToFormat,
   detectProjectRoot,

--- a/bin/skillsdock-core.mjs
+++ b/bin/skillsdock-core.mjs
@@ -4708,6 +4708,9 @@ async function cmdRemove(flags, args, context) {
   const force = Boolean(flags.force);
   const scope = typeof flags.scope === 'string' ? flags.scope : undefined;
 
+  if (isAll && args.length > 0) {
+    throw makeCliError('--all and <selector> are mutually exclusive. Use one or the other.', 2);
+  }
   if (isAll && !scope) {
     throw makeCliError('--all requires --scope user|project', 2);
   }
@@ -4732,6 +4735,9 @@ async function cmdRemove(flags, args, context) {
       allCopies: Boolean(flags['all-copies'] || flags.allCopies),
       includeDeleted: false
     });
+    if (scope) {
+      matches = matches.filter((item) => itemMatchesSourceScope(item, scope));
+    }
     if (matches.length === 0) {
       throw makeCliError(`Skill not found: ${selector}`, 2);
     }
@@ -4739,9 +4745,15 @@ async function cmdRemove(flags, args, context) {
 
   const scopesToProcess = scope ? [scope] : ['user', 'project'];
 
-  const counters = { files: 0, symlinks: 0, registryUpdated: 0, lockfileUpdated: 0 };
+  const counters = { files: 0, symlinks: 0, registryUpdated: 0, lockfileUpdated: 0, failed: 0 };
   const actions = [];
   const skipped = [];
+
+  let lockfileExists = false;
+  if (projectRoot) {
+    const lockPath = path.join(projectRoot, PROJECT_LOCKFILE_NAME);
+    lockfileExists = await pathExists(lockPath);
+  }
 
   for (const match of matches) {
     if (isFrozen(match) && !force) {
@@ -4753,7 +4765,7 @@ async function cmdRemove(flags, args, context) {
       const targets = await collectRemoveTargets(match, s, projectRoot, homeDir);
 
       for (const symlink of targets.symlinks) {
-        actions.push({ type: 'symlink', path: symlink, skill: match.id, scope: s });
+        actions.push({ type: 'symlink', path: symlink, skill: match.id, key: match.key, scope: s });
       }
 
       for (const filePath of targets.files) {
@@ -4762,13 +4774,13 @@ async function cmdRemove(flags, args, context) {
           { projectRoot, homeDir }
         );
         if (!isPathUnderBase(filePath, canonicalBase)) continue;
-        actions.push({ type: 'file', path: filePath, skill: match.id, scope: s });
+        actions.push({ type: 'file', path: filePath, skill: match.id, key: match.key, scope: s });
       }
     }
 
     actions.push({ type: 'registry', key: match.key, skill: match.id });
-    if (projectRoot) {
-      actions.push({ type: 'lockfile', skill: match.id, projectRoot });
+    if (projectRoot && lockfileExists) {
+      actions.push({ type: 'lockfile', skill: match.id, key: match.key, projectRoot });
     }
   }
 
@@ -4792,26 +4804,39 @@ async function cmdRemove(flags, args, context) {
     return;
   }
 
+  const failedKeys = new Set();
+
   for (const action of actions) {
     if (action.type === 'symlink') {
       try {
         await fs.unlink(action.path);
         counters.symlinks++;
       } catch (err) {
-        if (err?.code !== 'ENOENT') {
-          console.warn(`Warning: failed to remove symlink ${action.path}: ${err.message}`);
+        if (err?.code === 'ENOENT') {
+          continue;
         }
+        console.warn(`Error: failed to remove symlink ${action.path}: ${err.message}`);
+        failedKeys.add(action.key);
+        counters.failed++;
       }
     } else if (action.type === 'file') {
       try {
         await fs.rm(action.path, { recursive: true });
         counters.files++;
       } catch (err) {
-        if (err?.code !== 'ENOENT') {
-          console.warn(`Warning: failed to remove ${action.path}: ${err.message}`);
+        if (err?.code === 'ENOENT') {
+          continue;
         }
+        console.warn(`Error: failed to remove ${action.path}: ${err.message}`);
+        failedKeys.add(action.key);
+        counters.failed++;
       }
-    } else if (action.type === 'registry') {
+    }
+  }
+
+  for (const action of actions) {
+    if (action.type === 'registry') {
+      if (failedKeys.has(action.key)) continue;
       const key = action.key;
       if (registry.items[key]) {
         const now = new Date().toISOString();
@@ -4822,6 +4847,7 @@ async function cmdRemove(flags, args, context) {
         counters.registryUpdated++;
       }
     } else if (action.type === 'lockfile') {
+      if (failedKeys.has(action.key)) continue;
       try {
         await removeLockfileEntry(action.projectRoot, action.skill);
         counters.lockfileUpdated++;
@@ -4843,8 +4869,11 @@ async function cmdRemove(flags, args, context) {
   }
 
   console.log(
-    `Removed ${counters.files} dir(s), ${counters.symlinks} symlink(s), updated ${counters.registryUpdated} registry entry(ies), updated ${counters.lockfileUpdated} lockfile entry(ies)`
+    `Removed ${counters.files} dir(s), ${counters.symlinks} symlink(s), updated ${counters.registryUpdated} registry entry(ies), updated ${counters.lockfileUpdated} lockfile entry(ies)${counters.failed > 0 ? `, failed ${counters.failed}` : ''}`
   );
+  if (counters.failed > 0) {
+    process.exitCode = 1;
+  }
 }
 
 // ── node_modules skill discovery + sync ─────────────────────────────────

--- a/test/remove-command.test.mjs
+++ b/test/remove-command.test.mjs
@@ -1,0 +1,526 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, readFile, rm, symlink, lstat, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  normalizeRegistry,
+  readProjectLockfile,
+  writeProjectLockfile,
+  removeLockfileEntry,
+  cmdRemove
+} from '../bin/skillsdock-core.mjs';
+
+async function makeTmpDir() {
+  return mkdtemp(path.join(tmpdir(), 'skillsdock-remove-test-'));
+}
+
+async function withTmpDir(fn) {
+  const dir = await makeTmpDir();
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true });
+  }
+}
+
+async function pathExists(p) {
+  try {
+    await lstat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function buildRegistry(items = {}) {
+  return normalizeRegistry({ version: 2, items });
+}
+
+function makeSkillItem(id, canonicalPath, opts = {}) {
+  return {
+    id,
+    canonicalPath,
+    realPath: opts.realPath || canonicalPath,
+    sourcePath: canonicalPath,
+    name: opts.name || id,
+    description: opts.description || '',
+    normalized: { name: opts.name || id, description: '', body: '' },
+    hash: opts.hash || 'abc123',
+    policy: opts.policy || { tag: 'regular', reason: '', updatedAt: null },
+    state: opts.state || 'active',
+    sourceAliases: opts.sourceAliases || [{ name: 'test-source', agent: null, scope: opts.scope || 'user' }],
+    sourceName: 'test-source',
+    sourceAgent: null,
+    sourceScope: opts.scope || 'user'
+  };
+}
+
+async function setupSkillDir(base, skillId) {
+  const skillDir = path.join(base, '.agents', 'skills', skillId);
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(path.join(skillDir, 'SKILL.md'), `---\nname: "${skillId}"\n---\n# ${skillId}`, 'utf8');
+  return skillDir;
+}
+
+async function writeRegistry(registryPath, registry) {
+  await writeFile(registryPath, JSON.stringify(registry, null, 2) + '\n', 'utf8');
+}
+
+async function readRegistry(registryPath) {
+  const raw = await readFile(registryPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+// ── Basic remove ─────────────────────────────────────────────────────────
+
+test('remove: deletes skill directory and updates registry tag to deleted', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    const skillDir = await setupSkillDir(homeDir, 'my-skill');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'my-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('my-skill', canonicalPath, { scope: 'user' })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    const flags = { registry: registryPath, scope: 'user' };
+    const args = ['my-skill'];
+
+    await cmdRemove(flags, args, context);
+
+    assert.equal(await pathExists(skillDir), false, 'skill directory should be removed');
+
+    const updatedReg = await readRegistry(registryPath);
+    const key = `path:${canonicalPath}`;
+    assert.equal(updatedReg.items[key].policy.tag, 'deleted');
+    assert.equal(updatedReg.items[key].policy.reason, 'removed by skillsdock remove');
+  });
+});
+
+test('remove: also deletes symlinks from non-universal agent directories', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    const skillDir = await setupSkillDir(homeDir, 'link-skill');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'link-skill', 'SKILL.md');
+
+    const claudeSkillDir = path.join(homeDir, '.claude', 'skills', 'link-skill');
+    await mkdir(claudeSkillDir, { recursive: true });
+    const symlinkTarget = path.join(claudeSkillDir, 'SKILL.md');
+    const relTarget = path.relative(claudeSkillDir, path.join(skillDir, 'SKILL.md'));
+    await symlink(relTarget, symlinkTarget);
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('link-skill', canonicalPath, { scope: 'user' })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    const flags = { registry: registryPath, scope: 'user' };
+    const args = ['link-skill'];
+
+    await cmdRemove(flags, args, context);
+
+    assert.equal(await pathExists(skillDir), false, 'skill directory should be removed');
+    assert.equal(await pathExists(symlinkTarget), false, 'symlink in claude dir should be removed');
+  });
+});
+
+// ── Frozen protection ────────────────────────────────────────────────────
+
+test('remove: refuses to delete frozen skill without --force', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    const skillDir = await setupSkillDir(homeDir, 'frozen-skill');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'frozen-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('frozen-skill', canonicalPath, {
+        scope: 'user',
+        policy: { tag: 'frozen', reason: 'locked', updatedAt: '2026-01-01T00:00:00.000Z' }
+      })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    const flags = { registry: registryPath, scope: 'user' };
+    const args = ['frozen-skill'];
+
+    await cmdRemove(flags, args, context);
+
+    assert.equal(await pathExists(skillDir), true, 'frozen skill directory should NOT be removed');
+    const updatedReg = await readRegistry(registryPath);
+    const key = `path:${canonicalPath}`;
+    assert.equal(updatedReg.items[key].policy.tag, 'frozen', 'tag should remain frozen');
+  });
+});
+
+test('remove: --force deletes frozen skill', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    const skillDir = await setupSkillDir(homeDir, 'frozen-skill');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'frozen-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('frozen-skill', canonicalPath, {
+        scope: 'user',
+        policy: { tag: 'frozen', reason: 'locked', updatedAt: '2026-01-01T00:00:00.000Z' }
+      })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    const flags = { registry: registryPath, scope: 'user', force: true };
+    const args = ['frozen-skill'];
+
+    await cmdRemove(flags, args, context);
+
+    assert.equal(await pathExists(skillDir), false, 'frozen skill directory should be removed with --force');
+    const updatedReg = await readRegistry(registryPath);
+    const key = `path:${canonicalPath}`;
+    assert.equal(updatedReg.items[key].policy.tag, 'deleted');
+  });
+});
+
+// ── Dry run ──────────────────────────────────────────────────────────────
+
+test('remove: --dry-run does not modify files or registry', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    const skillDir = await setupSkillDir(homeDir, 'dry-skill');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'dry-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('dry-skill', canonicalPath, { scope: 'user' })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    const flags = { registry: registryPath, scope: 'user', 'dry-run': true };
+    const args = ['dry-skill'];
+
+    await cmdRemove(flags, args, context);
+
+    assert.equal(await pathExists(skillDir), true, 'skill directory should still exist after dry run');
+    const updatedReg = await readRegistry(registryPath);
+    const key = `path:${canonicalPath}`;
+    assert.equal(updatedReg.items[key].policy.tag, 'regular', 'tag should remain regular after dry run');
+  });
+});
+
+// ── --all mode ───────────────────────────────────────────────────────────
+
+test('remove: --all requires --scope', async () => {
+  await withTmpDir(async (base) => {
+    const registryPath = path.join(base, 'registry.json');
+    await writeRegistry(registryPath, buildRegistry({}));
+    const context = { cwd: base, projectRoot: base, homeDir: base };
+
+    await assert.rejects(
+      () => cmdRemove({ registry: registryPath, all: true }, [], context),
+      (err) => {
+        assert.match(err.message, /--all requires --scope/);
+        assert.equal(err.exitCode, 2);
+        return true;
+      }
+    );
+  });
+});
+
+test('remove: --all removes all skills in scope', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+
+    const skillDir1 = await setupSkillDir(homeDir, 'skill-a');
+    const skillDir2 = await setupSkillDir(homeDir, 'skill-b');
+    const registryPath = path.join(base, 'registry.json');
+
+    const cp1 = path.join(skillsBase, 'skill-a', 'SKILL.md');
+    const cp2 = path.join(skillsBase, 'skill-b', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${cp1}`]: makeSkillItem('skill-a', cp1, { scope: 'user' }),
+      [`path:${cp2}`]: makeSkillItem('skill-b', cp2, { scope: 'user' })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    const flags = { registry: registryPath, all: true, scope: 'user' };
+
+    await cmdRemove(flags, [], context);
+
+    assert.equal(await pathExists(skillDir1), false, 'skill-a should be removed');
+    assert.equal(await pathExists(skillDir2), false, 'skill-b should be removed');
+
+    const updatedReg = await readRegistry(registryPath);
+    assert.equal(updatedReg.items[`path:${cp1}`].policy.tag, 'deleted');
+    assert.equal(updatedReg.items[`path:${cp2}`].policy.tag, 'deleted');
+  });
+});
+
+// ── Lockfile update ──────────────────────────────────────────────────────
+
+test('remove: updates lockfile by removing skill entry', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    await setupSkillDir(homeDir, 'lock-skill');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'lock-skill', 'SKILL.md');
+
+    const lockData = {
+      version: 1,
+      skills: {
+        'lock-skill': { source: 'owner/repo', sourceType: 'github', computedHash: 'abc' },
+        'other-skill': { source: 'owner/repo2', sourceType: 'github', computedHash: 'def' }
+      }
+    };
+    await writeFile(path.join(base, 'skills-lock.json'), JSON.stringify(lockData, null, 2) + '\n', 'utf8');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('lock-skill', canonicalPath, { scope: 'user' })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    const flags = { registry: registryPath, scope: 'user' };
+    const args = ['lock-skill'];
+
+    await cmdRemove(flags, args, context);
+
+    const updatedLock = await readProjectLockfile(base);
+    assert.equal(updatedLock.skills['lock-skill'], undefined, 'lock-skill should be removed from lockfile');
+    assert.ok(updatedLock.skills['other-skill'], 'other-skill should remain in lockfile');
+  });
+});
+
+// ── Error cases ──────────────────────────────────────────────────────────
+
+test('remove: throws when no selector and no --all', async () => {
+  await withTmpDir(async (base) => {
+    const registryPath = path.join(base, 'registry.json');
+    await writeRegistry(registryPath, buildRegistry({}));
+    const context = { cwd: base, projectRoot: base, homeDir: base };
+
+    await assert.rejects(
+      () => cmdRemove({ registry: registryPath }, [], context),
+      (err) => {
+        assert.match(err.message, /Usage/);
+        assert.equal(err.exitCode, 2);
+        return true;
+      }
+    );
+  });
+});
+
+test('remove: throws when skill not found', async () => {
+  await withTmpDir(async (base) => {
+    const registryPath = path.join(base, 'registry.json');
+    await writeRegistry(registryPath, buildRegistry({}));
+    const context = { cwd: base, projectRoot: base, homeDir: base };
+
+    await assert.rejects(
+      () => cmdRemove({ registry: registryPath }, ['nonexistent'], context),
+      (err) => {
+        assert.match(err.message, /Skill not found/);
+        assert.equal(err.exitCode, 2);
+        return true;
+      }
+    );
+  });
+});
+
+test('remove: throws for invalid --scope', async () => {
+  await withTmpDir(async (base) => {
+    const registryPath = path.join(base, 'registry.json');
+    await writeRegistry(registryPath, buildRegistry({}));
+    const context = { cwd: base, projectRoot: base, homeDir: base };
+
+    await assert.rejects(
+      () => cmdRemove({ registry: registryPath, scope: 'invalid' }, ['some-skill'], context),
+      (err) => {
+        assert.match(err.message, /Invalid --scope/);
+        assert.equal(err.exitCode, 2);
+        return true;
+      }
+    );
+  });
+});
+
+// ── Project scope ────────────────────────────────────────────────────────
+
+test('remove: works with project scope', async () => {
+  await withTmpDir(async (base) => {
+    const projectRoot = path.join(base, 'project');
+    const skillsBase = path.join(projectRoot, '.agents', 'skills');
+    const skillDir = path.join(skillsBase, 'proj-skill');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(path.join(skillDir, 'SKILL.md'), `---\nname: "proj-skill"\n---\n# proj`, 'utf8');
+
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'proj-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('proj-skill', canonicalPath, { scope: 'project' })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: projectRoot, projectRoot, homeDir: path.join(base, 'home') };
+    const flags = { registry: registryPath, scope: 'project' };
+    const args = ['proj-skill'];
+
+    await cmdRemove(flags, args, context);
+
+    assert.equal(await pathExists(skillDir), false, 'project skill directory should be removed');
+  });
+});
+
+// ── --all with --dry-run ─────────────────────────────────────────────────
+
+test('remove: --all with --dry-run does not delete anything', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    const skillDir = await setupSkillDir(homeDir, 'dry-all-skill');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'dry-all-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('dry-all-skill', canonicalPath, { scope: 'user' })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    const flags = { registry: registryPath, all: true, scope: 'user', 'dry-run': true };
+
+    await cmdRemove(flags, [], context);
+
+    assert.equal(await pathExists(skillDir), true, 'dry run with --all should not remove skill');
+    const updatedReg = await readRegistry(registryPath);
+    assert.equal(updatedReg.items[`path:${canonicalPath}`].policy.tag, 'regular');
+  });
+});
+
+// ── Registry tag update ──────────────────────────────────────────────────
+
+test('remove: registry updatedAt is bumped after remove', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    await setupSkillDir(homeDir, 'ts-skill');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'ts-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('ts-skill', canonicalPath, { scope: 'user' })
+    });
+    registry.updatedAt = '2026-01-01T00:00:00.000Z';
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    await cmdRemove({ registry: registryPath, scope: 'user' }, ['ts-skill'], context);
+
+    const updatedReg = await readRegistry(registryPath);
+    assert.notEqual(updatedReg.updatedAt, '2026-01-01T00:00:00.000Z', 'updatedAt should be bumped');
+  });
+});
+
+// ── Frozen + --all: mixed behavior ───────────────────────────────────────
+
+test('remove: --all skips frozen skills, removes others', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    const regularDir = await setupSkillDir(homeDir, 'regular-skill');
+    const frozenDir = await setupSkillDir(homeDir, 'frozen-skill');
+    const registryPath = path.join(base, 'registry.json');
+
+    const cpRegular = path.join(skillsBase, 'regular-skill', 'SKILL.md');
+    const cpFrozen = path.join(skillsBase, 'frozen-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${cpRegular}`]: makeSkillItem('regular-skill', cpRegular, { scope: 'user' }),
+      [`path:${cpFrozen}`]: makeSkillItem('frozen-skill', cpFrozen, {
+        scope: 'user',
+        policy: { tag: 'frozen', reason: 'locked', updatedAt: '2026-01-01T00:00:00.000Z' }
+      })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    await cmdRemove({ registry: registryPath, all: true, scope: 'user' }, [], context);
+
+    assert.equal(await pathExists(regularDir), false, 'regular skill should be removed');
+    assert.equal(await pathExists(frozenDir), true, 'frozen skill should remain');
+
+    const updatedReg = await readRegistry(registryPath);
+    assert.equal(updatedReg.items[`path:${cpRegular}`].policy.tag, 'deleted');
+    assert.equal(updatedReg.items[`path:${cpFrozen}`].policy.tag, 'frozen');
+  });
+});
+
+// ── Already deleted skill ────────────────────────────────────────────────
+
+test('remove: ignores already-deleted skills in non-all mode', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const registryPath = path.join(base, 'registry.json');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    const canonicalPath = path.join(skillsBase, 'gone-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('gone-skill', canonicalPath, {
+        scope: 'user',
+        policy: { tag: 'deleted', reason: 'already removed', updatedAt: '2026-01-01T00:00:00.000Z' }
+      })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+
+    await assert.rejects(
+      () => cmdRemove({ registry: registryPath, scope: 'user' }, ['gone-skill'], context),
+      (err) => {
+        assert.match(err.message, /Skill not found/);
+        return true;
+      }
+    );
+  });
+});
+
+// ── Skill not on disk but in registry ────────────────────────────────────
+
+test('remove: updates registry even when skill dir does not exist on disk', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'phantom-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('phantom-skill', canonicalPath, { scope: 'user' })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    await cmdRemove({ registry: registryPath, scope: 'user' }, ['phantom-skill'], context);
+
+    const updatedReg = await readRegistry(registryPath);
+    assert.equal(updatedReg.items[`path:${canonicalPath}`].policy.tag, 'deleted');
+  });
+});

--- a/test/remove-command.test.mjs
+++ b/test/remove-command.test.mjs
@@ -5,6 +5,9 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
+
 import {
   normalizeRegistry,
   readProjectLockfile,
@@ -522,5 +525,126 @@ test('remove: updates registry even when skill dir does not exist on disk', asyn
 
     const updatedReg = await readRegistry(registryPath);
     assert.equal(updatedReg.items[`path:${canonicalPath}`].policy.tag, 'deleted');
+  });
+});
+
+// ── Fix: --all with selector is rejected ─────────────────────────────────
+
+test('remove: --all with a positional selector throws', async () => {
+  await withTmpDir(async (base) => {
+    const registryPath = path.join(base, 'registry.json');
+    await writeRegistry(registryPath, buildRegistry({}));
+    const context = { cwd: base, projectRoot: base, homeDir: base };
+
+    await assert.rejects(
+      () => cmdRemove({ registry: registryPath, all: true, scope: 'user' }, ['some-skill'], context),
+      (err) => {
+        assert.match(err.message, /mutually exclusive/);
+        assert.equal(err.exitCode, 2);
+        return true;
+      }
+    );
+  });
+});
+
+// ── Fix: single selector + --scope filters by scope ──────────────────────
+
+test('remove: single selector with --scope filters matches to that scope', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    await setupSkillDir(homeDir, 'scoped-skill');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'scoped-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('scoped-skill', canonicalPath, { scope: 'user' })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+
+    await assert.rejects(
+      () => cmdRemove({ registry: registryPath, scope: 'project' }, ['scoped-skill'], context),
+      (err) => {
+        assert.match(err.message, /Skill not found/);
+        return true;
+      }
+    );
+
+    const updatedReg = await readRegistry(registryPath);
+    assert.equal(updatedReg.items[`path:${canonicalPath}`].policy.tag, 'regular', 'should not have been modified');
+  });
+});
+
+// ── Fix: no lockfile created when none exists ────────────────────────────
+
+test('remove: does not create skills-lock.json when it does not already exist', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    await setupSkillDir(homeDir, 'no-lock-skill');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'no-lock-skill', 'SKILL.md');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('no-lock-skill', canonicalPath, { scope: 'user' })
+    });
+    await writeRegistry(registryPath, registry);
+
+    const lockPath = path.join(base, 'skills-lock.json');
+    assert.equal(fsSync.existsSync(lockPath), false, 'lockfile should not exist before remove');
+
+    const context = { cwd: base, projectRoot: base, homeDir };
+    await cmdRemove({ registry: registryPath, scope: 'user' }, ['no-lock-skill'], context);
+
+    assert.equal(fsSync.existsSync(lockPath), false, 'lockfile should not be created by remove');
+  });
+});
+
+// ── Fix: physical delete failure prevents registry/lockfile update ────────
+
+test('remove: does not update registry or lockfile when physical delete fails', async () => {
+  await withTmpDir(async (base) => {
+    const homeDir = path.join(base, 'home');
+    const skillsBase = path.join(homeDir, '.agents', 'skills');
+    const skillDir = await setupSkillDir(homeDir, 'perm-skill');
+    const registryPath = path.join(base, 'registry.json');
+    const canonicalPath = path.join(skillsBase, 'perm-skill', 'SKILL.md');
+
+    const lockData = {
+      version: 1,
+      skills: { 'perm-skill': { source: 'owner/repo', sourceType: 'github', computedHash: 'abc' } }
+    };
+    await writeFile(path.join(base, 'skills-lock.json'), JSON.stringify(lockData, null, 2) + '\n', 'utf8');
+
+    const registry = buildRegistry({
+      [`path:${canonicalPath}`]: makeSkillItem('perm-skill', canonicalPath, { scope: 'user' })
+    });
+    await writeRegistry(registryPath, registry);
+
+    await fs.chmod(skillsBase, 0o555);
+
+    const savedExitCode = process.exitCode;
+    const context = { cwd: base, projectRoot: base, homeDir };
+    try {
+      await cmdRemove({ registry: registryPath, scope: 'user' }, ['perm-skill'], context);
+    } catch {
+      // ignore
+    }
+    process.exitCode = savedExitCode;
+
+    await fs.chmod(skillsBase, 0o755);
+
+    const updatedReg = await readRegistry(registryPath);
+    const key = `path:${canonicalPath}`;
+    assert.notEqual(updatedReg.items[key].policy.tag, 'deleted',
+      'registry should NOT be updated to deleted when physical delete fails');
+
+    const updatedLock = await readProjectLockfile(base);
+    assert.ok(updatedLock.skills['perm-skill'],
+      'lockfile entry should NOT be removed when physical delete fails');
+
+    assert.equal(await pathExists(skillDir), true, 'skill directory should still exist');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `skillsdock remove` command (Issue #18) to clean up installed skill files, symlinks, and update registry/lockfile metadata.

## Changes

### Core Implementation (`bin/skillsdock-core.mjs`)

- **`cmdRemove(flags, args, context)`** — main remove command handler
  - Resolves skills via `resolveSelectorMatches()` (supports id, key, path selectors)
  - Deletes canonical skill directories under `.agents/skills/<skill-name>/`
  - Scans non-universal agent directories and removes symlinks pointing to canonical skills
  - Sets registry tag to `deleted` with `rebuildRegistryIndexes()` + `writeJson()`
  - Calls `removeLockfileEntry()` to clean up `skills-lock.json`
- **Helper functions:**
  - `findSymlinksPointingTo()` — recursive symlink scanner
  - `collectRemoveTargets()` — gathers files and symlinks to delete per skill/scope
  - `isPathUnderBase()` — path safety validation
- **Flags:**
  - `--scope user|project` — restrict to a specific scope
  - `--all --scope <scope>` — remove all skills in scope (`--scope` required)
  - `--dry-run` — preview all planned actions without writing
  - `--force` — bypass `frozen` tag protection
- Registered in `runCli()` dispatch chain
- Added to `printHelp()` usage text
- Exported `cmdRemove` for direct testing

### Correctness Fixes

1. **`--all` + selector rejection**: `--all` and a positional `<selector>` are now mutually exclusive; providing both throws a `makeCliError` with exit code 2.
2. **Scope filtering for single selector**: When `--scope` is provided with a single selector, `matches` are filtered via `itemMatchesSourceScope()` so only items belonging to the requested scope are processed. Prevents cross-scope metadata corruption.
3. **Lockfile guard**: The lockfile action is only queued when `skills-lock.json` already exists on disk, preventing `remove` from creating an empty lockfile as a side effect.
4. **Delete-failure consistency**: Physical delete operations (symlink unlink, directory rm) are executed in a first pass, tracking failures per registry key. Registry tag updates and `removeLockfileEntry()` calls only execute in a second pass for skills whose physical deletes all succeeded. ENOENT is treated as success; other errors mark the skill as failed, increment a failure counter, and set `process.exitCode = 1`.

### Tests (`test/remove-command.test.mjs`)

21 tests covering:
- Normal skill directory + registry deletion
- Symlink cleanup in non-universal agent directories
- `frozen` tag protection (refuses delete without `--force`)
- `--force` overrides frozen protection
- `--dry-run` previews without side effects
- `--all` mode with `--scope` requirement
- `--all` removes all matching skills
- `--all` with `--dry-run`
- `--all` skips frozen, removes regular
- Lockfile entry removal
- Project scope handling
- Registry `updatedAt` timestamp bump
- Error: missing selector without `--all`
- Error: skill not found
- Error: invalid `--scope`
- Already-deleted skills are ignored
- Registry update when skill dir doesn't exist on disk
- **`--all` with selector throws** (mutually exclusive guard)
- **Single selector + `--scope` filters by scope** (scope-mismatch → "Skill not found")
- **No lockfile creation when none exists** (no empty `skills-lock.json` side effect)
- **Physical delete failure prevents registry/lockfile update** (EACCES → metadata stays intact)

### Documentation

- `CHANGELOG.md` — added remove command under Unreleased/Added
- `README.md` — added `remove` to Commands block and new Remove section with examples

### Merge Conflicts

Resolved conflicts with `main` (add command + node_modules sync from Issues #17/#10) — both sides kept in CHANGELOG, README, and `skillsdock-core.mjs`.

## Quality Gates

- `npm test` — 195/195 pass (0 fail)
- `npm run pack:check` — passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32e163b0-5b75-4950-a725-3e64ba5e70cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32e163b0-5b75-4950-a725-3e64ba5e70cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加 `skillsdock remove` 子命令，支持按选择器或 `--all` 批量删除并提供 `--scope`/`--dry-run`/`--force`/`--all-copies` 等选项。
* **文档**
  * 更新 README 与 CHANGELOG，新增 Remove 小节，说明删除行为、冻结保护、干运行与作用域要求及示例。
* **测试**
  * 新增完整测试套件，覆盖正常删除、冻结/强制、干运行、批量删除、锁文件与注册表更新及错误情形。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->