### PR TITLE
feat(cli): add find command with skills.sh search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- `skillsdock find [query] [--json]` — search for skills in the skills.sh ecosystem:
+  - Non-interactive mode: `skillsdock find <query>` searches and prints a formatted results table
+  - Interactive mode: `skillsdock find` in a TTY launches a readline-based live search with debounce
+  - `--json` flag outputs machine-readable JSON array
+  - Defensive API response parsing (supports array, `{ results }`, and `{ skills }` formats)
+  - Graceful degradation for network errors, timeouts, and non-200 HTTP status codes
+  - Non-TTY without query shows usage hint
 - `skillsdock remove <selector>` — new command to clean up installed skill files, symlinks, and registry/lockfile entries:
   - Resolves skills by id, key, or path via `resolveSelectorMatches()`
   - Deletes canonical skill directories under `.agents/skills/`

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ skillsdock sync --to <agent|target> --scope <user|project> [--config <path>] [--
 skillsdock remove <selector> [--scope <user|project>] [--dry-run] [--force] [--all-copies]
 skillsdock remove --all --scope <user|project> [--dry-run] [--force]
 skillsdock add <source> [--scope user|project] [--dry-run] [--copy]
+skillsdock find [query] [--json]
 skillsdock sync --from node_modules [--scope user|project] [--dry-run]
 skillsdock doctor [--config <path>] [--registry <path>] [--agents] [--skills-spec]
 skillsdock version
@@ -219,6 +220,39 @@ skillsdock add ./my-skills --scope project
 # preview without writing
 skillsdock add acme/awesome-skills --dry-run
 ```
+
+## Find Command
+
+Search for skills in the [skills.sh](https://skills.sh) ecosystem.
+
+### Non-interactive mode
+
+```bash
+# search by keyword
+skillsdock find typescript
+
+# machine-readable JSON output
+skillsdock find react --json
+```
+
+Results are displayed as a formatted table with name, source, and description. Install a discovered skill with `skillsdock add <source>`.
+
+### Interactive mode
+
+When run without a query in a TTY terminal, `find` launches an interactive search:
+
+```bash
+skillsdock find
+# Search skills: _  (type to search, Enter to confirm, Ctrl+C to exit)
+```
+
+The interactive mode uses debounced input (200ms) to show live results as you type.
+
+### Error handling
+
+- Network unreachable: prints a connection error and exits with non-zero status
+- API errors (non-200): prints the HTTP status and exits with non-zero status
+- Timeout (5s): prints a timeout message and exits with non-zero status
 
 ## Sync Modes
 

--- a/bin/skillsdock-core.mjs
+++ b/bin/skillsdock-core.mjs
@@ -1898,6 +1898,7 @@ Usage:
   skillsdock remove <selector> [--scope <user|project>] [--dry-run] [--force] [--all-copies]
   skillsdock remove --all --scope <user|project> [--dry-run] [--force]
   skillsdock add <source> [--scope user|project] [--dry-run] [--copy]
+  skillsdock find [query] [--json]
   skillsdock sync --from node_modules [--scope user|project] [--dry-run]
   skillsdock doctor [--config <path>] [--registry <path>] [--agents] [--skills-spec]
   skillsdock version
@@ -1914,6 +1915,8 @@ Examples:
   skillsdock add owner/repo --scope user
   skillsdock add owner/repo@skill-name --dry-run
   skillsdock add ./path/to/skills --scope project
+  skillsdock find typescript
+  skillsdock find react --json
   skillsdock sync --from node_modules --dry-run
 `);
 }
@@ -5030,6 +5033,180 @@ async function cmdSyncFromNodeModules(flags, context) {
   );
 }
 
+const SKILLS_SEARCH_API = 'https://skills.sh/api/search';
+const SEARCH_TIMEOUT_MS = 5000;
+const SEARCH_DEFAULT_LIMIT = 10;
+const SEARCH_DEBOUNCE_MS = 200;
+
+async function searchSkills(query, options = {}) {
+  const fetchFn = options.fetch || globalThis.fetch;
+  const limit = options.limit || SEARCH_DEFAULT_LIMIT;
+  const url = `${SKILLS_SEARCH_API}?q=${encodeURIComponent(query)}&limit=${limit}`;
+
+  let response;
+  try {
+    response = await fetchFn(url, {
+      signal: AbortSignal.timeout(options.timeout || SEARCH_TIMEOUT_MS)
+    });
+  } catch (err) {
+    if (err && err.name === 'TimeoutError') {
+      throw makeCliError('Search timed out. Please try again.');
+    }
+    throw makeCliError('Unable to reach skills.sh. Check your internet connection.');
+  }
+
+  if (!response.ok) {
+    throw makeCliError(`Search failed: HTTP ${response.status}. Please try again later.`);
+  }
+
+  let data;
+  try {
+    data = await response.json();
+  } catch {
+    throw makeCliError('Search failed: invalid response from skills.sh.');
+  }
+
+  let results;
+  if (Array.isArray(data)) {
+    results = data;
+  } else if (data && Array.isArray(data.results)) {
+    results = data.results;
+  } else if (data && Array.isArray(data.skills)) {
+    results = data.skills;
+  } else {
+    results = [];
+  }
+
+  return results.map((item) => ({
+    name: item.name || '-',
+    source: item.source || '-',
+    description: item.description || '-'
+  }));
+}
+
+function formatFindResults(skills, query) {
+  const lines = [];
+  lines.push(`Found ${skills.length} skill${skills.length !== 1 ? 's' : ''} matching "${query}":\n`);
+
+  const columns = [
+    { label: 'NAME', get: (r) => r.name, min: 8, max: 24 },
+    { label: 'SOURCE', get: (r) => r.source, min: 8, max: 40 },
+    { label: 'DESCRIPTION', get: (r) => r.description, min: 8, max: 60 }
+  ];
+  const widths = columns.map((col) => {
+    const maxCell = Math.max(col.label.length, ...skills.map((row) => String(col.get(row) ?? '').length));
+    return Math.min(Math.max(maxCell, col.min || 8), col.max || 80);
+  });
+
+  lines.push(columns.map((col, i) => padCell(col.label, widths[i])).join('  '));
+  for (const row of skills) {
+    lines.push(columns.map((col, i) => padCell(col.get(row), widths[i])).join('  '));
+  }
+  lines.push('');
+  lines.push('Install with: skillsdock add <source>');
+  return lines.join('\n');
+}
+
+async function cmdFindInteractive(options = {}) {
+  const fetchFn = options.fetch || globalThis.fetch;
+  const { createInterface } = await import('node:readline');
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  let debounceTimer = null;
+
+  const doSearch = async (query) => {
+    if (!query || !query.trim()) return;
+    try {
+      const results = await searchSkills(query.trim(), { fetch: fetchFn });
+      if (results.length === 0) {
+        process.stdout.write(`\nNo skills found matching "${query.trim()}".\n`);
+      } else {
+        process.stdout.write('\n' + formatFindResults(results, query.trim()) + '\n');
+      }
+    } catch {
+      // Swallow errors during live search; final Enter search will report them
+    }
+  };
+
+  return new Promise((resolve) => {
+    rl.question('Search skills: ', async (answer) => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      rl.close();
+
+      const query = (answer || '').trim();
+      if (!query) {
+        resolve();
+        return;
+      }
+
+      try {
+        const results = await searchSkills(query, { fetch: fetchFn });
+        if (results.length === 0) {
+          console.log(`No skills found matching "${query}". Try a different search term.`);
+        } else {
+          console.log(formatFindResults(results, query));
+        }
+      } catch (err) {
+        throw err;
+      }
+      resolve();
+    });
+
+    rl.on('close', () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      resolve();
+    });
+
+    process.stdin.on('data', () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      const currentLine = rl.line || '';
+      if (currentLine.trim()) {
+        debounceTimer = setTimeout(() => doSearch(currentLine), SEARCH_DEBOUNCE_MS);
+      }
+    });
+  });
+}
+
+async function cmdFind(flags, args, context) {
+  const query = args[0];
+  const isJson = Boolean(flags.json);
+  const fetchFn = (context && context.fetch) || globalThis.fetch;
+  const isTTY = process.stdout.isTTY && process.stdin.isTTY;
+
+  if (!query) {
+    if (isTTY) {
+      await cmdFindInteractive({ fetch: fetchFn });
+      return;
+    }
+    const usageText = [
+      'Usage: skillsdock find <query> [--json]',
+      '',
+      'Search for skills in the skills.sh ecosystem.',
+      'Run in a terminal for interactive search.'
+    ].join('\n');
+    console.log(usageText);
+    return;
+  }
+
+  const results = await searchSkills(query, { fetch: fetchFn });
+
+  if (isJson) {
+    console.log(JSON.stringify(results));
+    return;
+  }
+
+  if (results.length === 0) {
+    console.log(`No skills found matching "${query}". Try a different search term.`);
+    return;
+  }
+
+  console.log(formatFindResults(results, query));
+}
+
 export async function runCli(argv = process.argv.slice(2), options = {}) {
   const { flags, positional } = parseArgs(argv);
   const command = positional[0];
@@ -5089,6 +5266,10 @@ export async function runCli(argv = process.argv.slice(2), options = {}) {
     await cmdAdd(flags, args, context);
     return;
   }
+  if (command === 'find') {
+    await cmdFind(flags, args, context);
+    return;
+  }
   if (command === 'doctor') {
     await cmdDoctor(flags, context);
     return;
@@ -5107,7 +5288,9 @@ export {
   buildDefaultConfig,
   buildDoctorAgentMatrixRows,
   buildCleanupPlan,
+  cmdFind,
   cmdRemove,
+  searchSkills,
   computeSkillFolderHash,
   convertContentToFormat,
   detectProjectRoot,

--- a/bin/skillsdock-core.mjs
+++ b/bin/skillsdock-core.mjs
@@ -5077,11 +5077,13 @@ async function searchSkills(query, options = {}) {
     results = [];
   }
 
-  return results.map((item) => ({
-    name: item.name || '-',
-    source: item.source || '-',
-    description: item.description || '-'
-  }));
+  return results
+    .filter((item) => typeof item === 'object' && item !== null)
+    .map((item) => ({
+      name: typeof item.name === 'string' ? item.name : '-',
+      source: typeof item.source === 'string' ? item.source : '-',
+      description: typeof item.description === 'string' ? item.description : '-'
+    }));
 }
 
 function formatFindResults(skills, query) {
@@ -5112,34 +5114,55 @@ async function cmdFindInteractive(options = {}) {
   const { createInterface } = await import('node:readline');
 
   const rl = createInterface({
-    input: process.stdin,
-    output: process.stdout
+    input: options.stdin || process.stdin,
+    output: options.stdout || process.stdout
   });
 
   let debounceTimer = null;
+  let settled = false;
 
   const doSearch = async (query) => {
     if (!query || !query.trim()) return;
     try {
       const results = await searchSkills(query.trim(), { fetch: fetchFn });
       if (results.length === 0) {
-        process.stdout.write(`\nNo skills found matching "${query.trim()}".\n`);
+        (options.stdout || process.stdout).write(`\nNo skills found matching "${query.trim()}".\n`);
       } else {
-        process.stdout.write('\n' + formatFindResults(results, query.trim()) + '\n');
+        (options.stdout || process.stdout).write('\n' + formatFindResults(results, query.trim()) + '\n');
       }
     } catch {
       // Swallow errors during live search; final Enter search will report them
     }
   };
 
-  return new Promise((resolve) => {
-    rl.question('Search skills: ', async (answer) => {
-      if (debounceTimer) clearTimeout(debounceTimer);
-      rl.close();
+  const stdinSource = options.stdin || process.stdin;
+  const onData = () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    const currentLine = rl.line || '';
+    if (currentLine.trim()) {
+      debounceTimer = setTimeout(() => doSearch(currentLine), SEARCH_DEBOUNCE_MS);
+    }
+  };
 
+  const cleanup = () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = null;
+    stdinSource.removeListener('data', onData);
+  };
+
+  return new Promise((resolve, reject) => {
+    const settle = (err) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (err) reject(err); else resolve();
+    };
+
+    rl.question('Search skills: ', async (answer) => {
       const query = (answer || '').trim();
       if (!query) {
-        resolve();
+        rl.close();
+        settle();
         return;
       }
 
@@ -5150,24 +5173,18 @@ async function cmdFindInteractive(options = {}) {
         } else {
           console.log(formatFindResults(results, query));
         }
+        settle();
       } catch (err) {
-        throw err;
+        settle(err);
       }
-      resolve();
+      rl.close();
     });
 
     rl.on('close', () => {
-      if (debounceTimer) clearTimeout(debounceTimer);
-      resolve();
+      settle();
     });
 
-    process.stdin.on('data', () => {
-      if (debounceTimer) clearTimeout(debounceTimer);
-      const currentLine = rl.line || '';
-      if (currentLine.trim()) {
-        debounceTimer = setTimeout(() => doSearch(currentLine), SEARCH_DEBOUNCE_MS);
-      }
-    });
+    stdinSource.on('data', onData);
   });
 }
 
@@ -5289,6 +5306,7 @@ export {
   buildDoctorAgentMatrixRows,
   buildCleanupPlan,
   cmdFind,
+  cmdFindInteractive,
   cmdRemove,
   searchSkills,
   computeSkillFolderHash,

--- a/test/find-command.test.mjs
+++ b/test/find-command.test.mjs
@@ -4,7 +4,9 @@ import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { cmdFind, searchSkills } from '../bin/skillsdock-core.mjs';
+import { Readable, Writable } from 'node:stream';
+
+import { cmdFind, cmdFindInteractive, searchSkills } from '../bin/skillsdock-core.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
@@ -91,6 +93,22 @@ test('searchSkills: tolerates missing fields with defaults', async () => {
   assert.equal(results[0].description, '-');
   assert.equal(results[1].name, '-');
   assert.equal(results[2].description, 'only desc');
+});
+
+test('searchSkills: filters out non-object elements (null, primitives)', async () => {
+  const mockFetch = makeMockFetch([null, 'string', 42, { name: 'valid', source: 'owner/repo', description: 'ok' }, undefined]);
+  const results = await searchSkills('test', { fetch: mockFetch });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].name, 'valid');
+});
+
+test('searchSkills: treats non-string property values as missing', async () => {
+  const mockFetch = makeMockFetch([{ name: 123, source: true, description: null }]);
+  const results = await searchSkills('test', { fetch: mockFetch });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].name, '-');
+  assert.equal(results[0].source, '-');
+  assert.equal(results[0].description, '-');
 });
 
 test('searchSkills: network error throws CliError', async () => {
@@ -290,4 +308,150 @@ test('searchSkills: passes query and limit in URL', async () => {
   await searchSkills('my query', { fetch: mockFetch, limit: 5 });
   assert.ok(capturedUrl.includes('q=my%20query'));
   assert.ok(capturedUrl.includes('limit=5'));
+});
+
+// ── cmdFindInteractive tests ──
+
+function makeFakeStdin() {
+  const stream = new Readable({ read() {} });
+  stream.isTTY = true;
+  stream.setRawMode = () => stream;
+  return stream;
+}
+
+function makeFakeStdout() {
+  let buf = '';
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      buf += chunk.toString();
+      cb();
+    }
+  });
+  stream.isTTY = true;
+  stream.columns = 120;
+  stream.getContent = () => buf;
+  return stream;
+}
+
+test('cmdFindInteractive: submits query on Enter and displays results', async () => {
+  const fakeStdin = makeFakeStdin();
+  const fakeStdout = makeFakeStdout();
+  let searchCount = 0;
+  const mockFetch = makeMockFetch(MOCK_RESULTS);
+  const wrappedFetch = async (...a) => {
+    searchCount++;
+    return mockFetch(...a);
+  };
+
+  const p = cmdFindInteractive({
+    fetch: wrappedFetch,
+    stdin: fakeStdin,
+    stdout: fakeStdout
+  });
+
+  await new Promise((r) => setTimeout(r, 50));
+  fakeStdin.push('typescript\n');
+
+  await p;
+  assert.ok(searchCount >= 1, 'searchSkills should have been called at least once');
+  fakeStdin.destroy();
+});
+
+test('cmdFindInteractive: empty input resolves without searching', async () => {
+  const fakeStdin = makeFakeStdin();
+  const fakeStdout = makeFakeStdout();
+  let searchCount = 0;
+  const mockFetch = async () => {
+    searchCount++;
+    return { ok: true, status: 200, json: async () => [] };
+  };
+
+  const p = cmdFindInteractive({
+    fetch: mockFetch,
+    stdin: fakeStdin,
+    stdout: fakeStdout
+  });
+
+  await new Promise((r) => setTimeout(r, 50));
+  fakeStdin.push('\n');
+
+  await p;
+  assert.equal(searchCount, 0, 'No search should be triggered for empty input');
+  fakeStdin.destroy();
+});
+
+test('cmdFindInteractive: early stream close resolves cleanly', async () => {
+  const fakeStdin = makeFakeStdin();
+  const fakeStdout = makeFakeStdout();
+  let searchCount = 0;
+  const mockFetch = async () => {
+    searchCount++;
+    return { ok: true, status: 200, json: async () => MOCK_RESULTS };
+  };
+
+  const p = cmdFindInteractive({
+    fetch: mockFetch,
+    stdin: fakeStdin,
+    stdout: fakeStdout
+  });
+
+  await new Promise((r) => setTimeout(r, 50));
+  fakeStdin.push(null);
+
+  await p;
+  assert.equal(searchCount, 0, 'No pending search should run after stream close');
+});
+
+test('cmdFindInteractive: debounce collapses rapid keystrokes into fewer searches', async () => {
+  const fakeStdin = makeFakeStdin();
+  const fakeStdout = makeFakeStdout();
+  let searchCount = 0;
+  const mockFetch = async () => {
+    searchCount++;
+    return { ok: true, status: 200, json: async () => MOCK_RESULTS };
+  };
+
+  const p = cmdFindInteractive({
+    fetch: mockFetch,
+    stdin: fakeStdin,
+    stdout: fakeStdout
+  });
+
+  await new Promise((r) => setTimeout(r, 30));
+
+  fakeStdin.push('t');
+  await new Promise((r) => setTimeout(r, 50));
+  fakeStdin.push('y');
+  await new Promise((r) => setTimeout(r, 50));
+  fakeStdin.push('p');
+  await new Promise((r) => setTimeout(r, 50));
+
+  const countBeforeEnter = searchCount;
+
+  fakeStdin.push('\n');
+  await p;
+
+  assert.ok(countBeforeEnter <= 2, `Expected debounce to collapse keystrokes, got ${countBeforeEnter} calls before Enter`);
+  fakeStdin.destroy();
+});
+
+test('cmdFindInteractive: network error rejects the promise', async () => {
+  const fakeStdin = makeFakeStdin();
+  const fakeStdout = makeFakeStdout();
+  const mockFetch = makeMockFetch(null, { shouldThrow: true });
+
+  const p = cmdFindInteractive({
+    fetch: mockFetch,
+    stdin: fakeStdin,
+    stdout: fakeStdout
+  });
+
+  await new Promise((r) => setTimeout(r, 50));
+  fakeStdin.push('test\n');
+
+  await assert.rejects(p, (err) => {
+    assert.ok(err.message.includes('Unable to reach skills.sh'));
+    return true;
+  });
+  fakeStdin.destroy();
 });

--- a/test/find-command.test.mjs
+++ b/test/find-command.test.mjs
@@ -1,0 +1,293 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { cmdFind, searchSkills } from '../bin/skillsdock-core.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'skillsdock.mjs');
+
+function runCliProcess(args, envOverrides = {}) {
+  const { XDG_STATE_HOME, ...cleanEnv } = process.env;
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...cleanEnv,
+      ...envOverrides
+    }
+  });
+  return result;
+}
+
+function makeMockFetch(responseBody, options = {}) {
+  const { status = 200, shouldThrow = false, throwError = null } = options;
+  return async (_url, _opts) => {
+    if (shouldThrow) {
+      throw throwError || new Error('Network error');
+    }
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => responseBody
+    };
+  };
+}
+
+function makeTimeoutFetch() {
+  return async (_url, opts) => {
+    const err = new Error('The operation was aborted due to timeout');
+    err.name = 'TimeoutError';
+    throw err;
+  };
+}
+
+const MOCK_RESULTS = [
+  { name: 'typescript', source: 'vercel-labs/skills', description: 'TypeScript best practices' },
+  { name: 'ts-strict', source: 'someuser/skills', description: 'Strict TypeScript config' },
+  { name: 'ts-node', source: 'anotheruser/repo', description: 'TypeScript Node.js setup' }
+];
+
+// ── searchSkills unit tests ──
+
+test('searchSkills: parses array response', async () => {
+  const mockFetch = makeMockFetch(MOCK_RESULTS);
+  const results = await searchSkills('typescript', { fetch: mockFetch });
+  assert.equal(results.length, 3);
+  assert.equal(results[0].name, 'typescript');
+  assert.equal(results[0].source, 'vercel-labs/skills');
+  assert.equal(results[0].description, 'TypeScript best practices');
+});
+
+test('searchSkills: parses { results: [...] } response', async () => {
+  const mockFetch = makeMockFetch({ results: MOCK_RESULTS });
+  const results = await searchSkills('typescript', { fetch: mockFetch });
+  assert.equal(results.length, 3);
+  assert.equal(results[1].name, 'ts-strict');
+});
+
+test('searchSkills: parses { skills: [...] } response', async () => {
+  const mockFetch = makeMockFetch({ skills: MOCK_RESULTS.slice(0, 1) });
+  const results = await searchSkills('typescript', { fetch: mockFetch });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].name, 'typescript');
+});
+
+test('searchSkills: returns empty array for unexpected format', async () => {
+  const mockFetch = makeMockFetch({ something: 'unexpected' });
+  const results = await searchSkills('test', { fetch: mockFetch });
+  assert.deepEqual(results, []);
+});
+
+test('searchSkills: tolerates missing fields with defaults', async () => {
+  const mockFetch = makeMockFetch([{ name: 'partial' }, {}, { description: 'only desc' }]);
+  const results = await searchSkills('test', { fetch: mockFetch });
+  assert.equal(results.length, 3);
+  assert.equal(results[0].name, 'partial');
+  assert.equal(results[0].source, '-');
+  assert.equal(results[0].description, '-');
+  assert.equal(results[1].name, '-');
+  assert.equal(results[2].description, 'only desc');
+});
+
+test('searchSkills: network error throws CliError', async () => {
+  const mockFetch = makeMockFetch(null, { shouldThrow: true });
+  await assert.rejects(
+    () => searchSkills('test', { fetch: mockFetch }),
+    (err) => {
+      assert.ok(err.message.includes('Unable to reach skills.sh'));
+      return true;
+    }
+  );
+});
+
+test('searchSkills: timeout error throws CliError', async () => {
+  const mockFetch = makeTimeoutFetch();
+  await assert.rejects(
+    () => searchSkills('test', { fetch: mockFetch }),
+    (err) => {
+      assert.ok(err.message.includes('Search timed out'));
+      return true;
+    }
+  );
+});
+
+test('searchSkills: non-200 status throws CliError', async () => {
+  const mockFetch = makeMockFetch(null, { status: 503 });
+  await assert.rejects(
+    () => searchSkills('test', { fetch: mockFetch }),
+    (err) => {
+      assert.ok(err.message.includes('Search failed: HTTP 503'));
+      return true;
+    }
+  );
+});
+
+test('searchSkills: empty array result', async () => {
+  const mockFetch = makeMockFetch([]);
+  const results = await searchSkills('nonexistent', { fetch: mockFetch });
+  assert.deepEqual(results, []);
+});
+
+// ── cmdFind unit tests ──
+
+test('cmdFind: prints formatted table for normal results', async () => {
+  const mockFetch = makeMockFetch(MOCK_RESULTS);
+  const output = [];
+  const origLog = console.log;
+  console.log = (...a) => output.push(a.join(' '));
+  try {
+    await cmdFind({}, ['typescript'], { fetch: mockFetch });
+  } finally {
+    console.log = origLog;
+  }
+  const text = output.join('\n');
+  assert.ok(text.includes('Found 3 skills matching "typescript"'));
+  assert.ok(text.includes('NAME'));
+  assert.ok(text.includes('SOURCE'));
+  assert.ok(text.includes('DESCRIPTION'));
+  assert.ok(text.includes('typescript'));
+  assert.ok(text.includes('vercel-labs/skills'));
+  assert.ok(text.includes('Install with: skillsdock add <source>'));
+});
+
+test('cmdFind: prints "no skills found" for empty results', async () => {
+  const mockFetch = makeMockFetch([]);
+  const output = [];
+  const origLog = console.log;
+  console.log = (...a) => output.push(a.join(' '));
+  try {
+    await cmdFind({}, ['nonexistent'], { fetch: mockFetch });
+  } finally {
+    console.log = origLog;
+  }
+  const text = output.join('\n');
+  assert.ok(text.includes('No skills found matching "nonexistent"'));
+  assert.ok(text.includes('Try a different search term'));
+});
+
+test('cmdFind: --json outputs pure JSON array', async () => {
+  const mockFetch = makeMockFetch(MOCK_RESULTS);
+  const output = [];
+  const origLog = console.log;
+  console.log = (...a) => output.push(a.join(' '));
+  try {
+    await cmdFind({ json: true }, ['typescript'], { fetch: mockFetch });
+  } finally {
+    console.log = origLog;
+  }
+  const text = output.join('\n');
+  const parsed = JSON.parse(text);
+  assert.ok(Array.isArray(parsed));
+  assert.equal(parsed.length, 3);
+  assert.equal(parsed[0].name, 'typescript');
+});
+
+test('cmdFind: --json outputs empty array for no results', async () => {
+  const mockFetch = makeMockFetch([]);
+  const output = [];
+  const origLog = console.log;
+  console.log = (...a) => output.push(a.join(' '));
+  try {
+    await cmdFind({ json: true }, ['nonexistent'], { fetch: mockFetch });
+  } finally {
+    console.log = origLog;
+  }
+  const text = output.join('\n');
+  const parsed = JSON.parse(text);
+  assert.deepEqual(parsed, []);
+});
+
+test('cmdFind: no query in non-TTY shows usage', async () => {
+  const output = [];
+  const origLog = console.log;
+  console.log = (...a) => output.push(a.join(' '));
+  try {
+    await cmdFind({}, [], {});
+  } finally {
+    console.log = origLog;
+  }
+  const text = output.join('\n');
+  assert.ok(text.includes('Usage: skillsdock find'));
+  assert.ok(text.includes('Search for skills'));
+});
+
+test('cmdFind: network error propagates', async () => {
+  const mockFetch = makeMockFetch(null, { shouldThrow: true });
+  await assert.rejects(
+    () => cmdFind({}, ['test'], { fetch: mockFetch }),
+    (err) => {
+      assert.ok(err.message.includes('Unable to reach skills.sh'));
+      return true;
+    }
+  );
+});
+
+test('cmdFind: timeout error propagates', async () => {
+  const mockFetch = makeTimeoutFetch();
+  await assert.rejects(
+    () => cmdFind({}, ['test'], { fetch: mockFetch }),
+    (err) => {
+      assert.ok(err.message.includes('Search timed out'));
+      return true;
+    }
+  );
+});
+
+test('cmdFind: HTTP error propagates', async () => {
+  const mockFetch = makeMockFetch(null, { status: 500 });
+  await assert.rejects(
+    () => cmdFind({}, ['test'], { fetch: mockFetch }),
+    (err) => {
+      assert.ok(err.message.includes('Search failed: HTTP 500'));
+      return true;
+    }
+  );
+});
+
+// ── CLI integration tests (via spawnSync) ──
+
+test('cli: find --help shows find in help text', () => {
+  const result = runCliProcess(['--help']);
+  assert.equal(result.status, 0);
+  assert.ok(result.stdout.includes('find'));
+});
+
+test('cli: find with no query in non-TTY shows usage', () => {
+  const result = runCliProcess(['find']);
+  assert.equal(result.status, 0);
+  assert.ok(result.stdout.includes('Usage: skillsdock find'));
+});
+
+test('cmdFind: defensive response format — invalid JSON body', async () => {
+  const mockFetch = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => { throw new SyntaxError('Unexpected token'); }
+  });
+  await assert.rejects(
+    () => cmdFind({}, ['test'], { fetch: mockFetch }),
+    (err) => {
+      assert.ok(err.message.includes('invalid response'));
+      return true;
+    }
+  );
+});
+
+test('searchSkills: passes query and limit in URL', async () => {
+  let capturedUrl;
+  const mockFetch = async (url) => {
+    capturedUrl = url;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => []
+    };
+  };
+  await searchSkills('my query', { fetch: mockFetch, limit: 5 });
+  assert.ok(capturedUrl.includes('q=my%20query'));
+  assert.ok(capturedUrl.includes('limit=5'));
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `skillsdock find` command for discovering skills from the [skills.sh](https://skills.sh) ecosystem.

Closes #20

## Features

### Non-interactive mode
```bash
skillsdock find typescript         # formatted table output
skillsdock find react --json       # machine-readable JSON output
```

### Interactive mode (TTY only)
```bash
skillsdock find                    # launches readline-based live search
```

### Error handling
- Network unreachable → `Unable to reach skills.sh. Check your internet connection.`
- HTTP errors → `Search failed: HTTP <status>. Please try again later.`
- Timeout (5s) → `Search timed out. Please try again.`
- Non-TTY without query → usage hint

### API response parsing
Defensively handles multiple response formats:
- Direct array: `[{ name, source, description }]`
- Wrapped: `{ results: [...] }` or `{ skills: [...] }`
- Non-object elements (null, primitives) are filtered out
- Non-string property values default to `"-"`

## Implementation details

- **No new dependencies** — uses only Node.js built-in modules (`readline`, `fetch`, `AbortSignal.timeout`)
- `searchSkills(query, options)` — core search function, accepts `context.fetch` for test injection
- `cmdFind(flags, args, context)` — command handler following existing patterns
- `cmdFindInteractive(options)` — TTY interactive mode with 200ms debounce, proper settled-flag to prevent double-resolution, stdin listener cleanup

## Tests

28 tests in `test/find-command.test.mjs`:
- `searchSkills` unit tests: array response, `{ results }` wrapper, `{ skills }` wrapper, unexpected format, missing fields, non-object elements, non-string property types, network error, timeout, HTTP error, empty results, URL parameter encoding
- `cmdFind` unit tests: formatted table output, empty results, `--json` output, non-TTY usage hint, error propagation (network, timeout, HTTP), invalid JSON body
- `cmdFindInteractive` tests: Enter submits query, empty input resolves cleanly, early stream close, debounce collapses rapid keystrokes, network error rejection
- CLI integration tests: `--help` includes find, non-TTY without query

## Quality gates

- ✅ `npm test` — 223/223 tests pass (195 existing + 28 new)
- ✅ `npm run pack:check` — tarball contents verified
- ✅ No new npm dependencies
- ✅ CHANGELOG.md updated
- ✅ README.md updated with find command documentation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52c2025e-a55d-44f5-a9c1-342353c40b42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52c2025e-a55d-44f5-a9c1-342353c40b42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 新增 `skillsdock find [query] [--json]`：支持非交互关键字搜索与交互式 TTY 搜索（空查询进入提示并实时更新，输入防抖 200ms）。
  * `--json` 输出机器可读的纯数组；默认以表格化文本列出结果并提示安装命令。

* **错误处理**
  * 明确网络不可达、非 200 响应与 5 秒超时提示并以非零状态退出；非 TTY 无查询时给出使用提示。

* **文档**
  * 更新 README 与 CHANGELOG，补充命令说明与示例。

* **测试**
  * 添加覆盖多种响应格式、字段缺失、错误与交互行为的测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->