### PR TITLE
feat(cli): add check/update commands for skill freshness detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `skillsdock check [--json]` — detect available updates for installed skills via the GitHub Trees API:
   - Reads both `skills-lock.json` and the SkillsDock registry for tracked skills
   - Uses GitHub Trees API (`GET /repos/{owner}/{repo}/git/trees/{branch}?recursive=1`) with one API call per repository (batches skills from the same repo)
-  - Computes a SHA-256 fingerprint from the remote tree to compare against the locally stored hash
+  - Computes a SHA-256 fingerprint from remote tree blob SHAs and compares against a locally stored `treeSha` field (same hash domain as GitHub API, avoiding false positives from content-vs-git-object hash mismatches)
   - Text output shows up-to-date count, skills with updates, and skipped skills
   - `--json` outputs machine-readable JSON (no ANSI escape codes)
   - Skips non-GitHub sources (local, GitLab) with a reason in the report
@@ -15,13 +15,16 @@
 - `skillsdock update [--scope user|project] [--dry-run]` — automatically re-install skills that have available updates:
   - Runs the same freshness detection as `check`
   - Re-clones and re-installs outdated skills using `installSkillToTarget()`
-  - Updates `skills-lock.json` with new content hashes after installation
+  - Updates `skills-lock.json` with new content hashes and `treeSha` after installation
   - `--dry-run` previews which skills would be updated without writing files
   - `--scope user|project` controls the installation target (default: `project`)
   - Prints an update summary: updated count, already up to date, skipped
 - `resolveGitHubToken()` — resolves a GitHub token with priority: `GITHUB_TOKEN` env var > `GH_TOKEN` env var > `gh auth token` CLI fallback; unauthenticated requests still work (60 req/hr)
 - Exported `installSkillToTarget()` for reuse in `cmdUpdate`
-- Test suite `test/check-update.test.mjs` covering token resolution, update detection, batching, network errors, rate limits, JSON output, dry-run, CLI integration, and mixed scenarios (26 tests)
+- `computeLocalTreeFingerprint(repoDir, subpath)` — computes a tree fingerprint from a local git clone using `git ls-tree -r HEAD`, producing hashes in the same domain as the GitHub Trees API (git blob SHA-1s)
+- `treeSha` field added to `skills-lock.json` entries for GitHub-sourced skills — stores the tree fingerprint at install time for reliable freshness detection
+- Pre-existing lockfile entries without `treeSha` are treated as needing update (one-time migration)
+- Test suite `test/check-update.test.mjs` covering token resolution, update detection, treeSha-based comparison, legacy entries without treeSha, batching, network errors, rate limits, JSON output, dry-run, CLI integration, and mixed scenarios (27 tests)
 
 - `skillsdock remove <selector>` — new command to clean up installed skill files, symlinks, and registry/lockfile entries:
   - Resolves skills by id, key, or path via `resolveSelectorMatches()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### Added
 
+- `skillsdock check [--json]` — detect available updates for installed skills via the GitHub Trees API:
+  - Reads both `skills-lock.json` and the SkillsDock registry for tracked skills
+  - Uses GitHub Trees API (`GET /repos/{owner}/{repo}/git/trees/{branch}?recursive=1`) with one API call per repository (batches skills from the same repo)
+  - Computes a SHA-256 fingerprint from the remote tree to compare against the locally stored hash
+  - Text output shows up-to-date count, skills with updates, and skipped skills
+  - `--json` outputs machine-readable JSON (no ANSI escape codes)
+  - Skips non-GitHub sources (local, GitLab) with a reason in the report
+  - Graceful degradation on network errors and API rate limits
+- `skillsdock update [--scope user|project] [--dry-run]` — automatically re-install skills that have available updates:
+  - Runs the same freshness detection as `check`
+  - Re-clones and re-installs outdated skills using `installSkillToTarget()`
+  - Updates `skills-lock.json` with new content hashes after installation
+  - `--dry-run` previews which skills would be updated without writing files
+  - `--scope user|project` controls the installation target (default: `project`)
+  - Prints an update summary: updated count, already up to date, skipped
+- `resolveGitHubToken()` — resolves a GitHub token with priority: `GITHUB_TOKEN` env var > `GH_TOKEN` env var > `gh auth token` CLI fallback; unauthenticated requests still work (60 req/hr)
+- Exported `installSkillToTarget()` for reuse in `cmdUpdate`
+- Test suite `test/check-update.test.mjs` covering token resolution, update detection, batching, network errors, rate limits, JSON output, dry-run, CLI integration, and mixed scenarios (26 tests)
+
 - `skillsdock remove <selector>` — new command to clean up installed skill files, symlinks, and registry/lockfile entries:
   - Resolves skills by id, key, or path via `resolveSelectorMatches()`
   - Deletes canonical skill directories under `.agents/skills/`

--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ skillsdock add ./path/to/skills --scope project
 # preview what would be installed
 skillsdock add owner/repo --dry-run
 
+# check for skill updates
+skillsdock check
+
+# check for updates (JSON output)
+skillsdock check --json
+
+# update outdated skills
+skillsdock update --scope project
+
+# preview updates without installing
+skillsdock update --dry-run
+
 # inspect built-in agent compatibility + detection
 skillsdock doctor --agents
 ```
@@ -141,6 +153,8 @@ skillsdock remove <selector> [--scope <user|project>] [--dry-run] [--force] [--a
 skillsdock remove --all --scope <user|project> [--dry-run] [--force]
 skillsdock add <source> [--scope user|project] [--dry-run] [--copy]
 skillsdock sync --from node_modules [--scope user|project] [--dry-run]
+skillsdock check [--json]
+skillsdock update [--scope user|project] [--dry-run]
 skillsdock doctor [--config <path>] [--registry <path>] [--agents] [--skills-spec]
 skillsdock version
 ```
@@ -218,6 +232,93 @@ skillsdock add ./my-skills --scope project
 
 # preview without writing
 skillsdock add acme/awesome-skills --dry-run
+```
+
+## Check Command
+
+`skillsdock check` detects available updates for installed skills by comparing local content hashes against remote GitHub tree data.
+
+### How It Works
+
+1. Reads tracked skills from `skills-lock.json` and the SkillsDock registry
+2. For each GitHub-sourced skill, fetches the repository tree via the GitHub Trees API
+3. Skills from the same repository are batched into a single API call (avoids N+1)
+4. Computes a SHA-256 fingerprint from the remote tree and compares it to the locally stored hash
+5. Reports which skills are up to date, which have updates, and which were skipped
+
+### Options
+
+- `--json` — Output machine-readable JSON instead of human-readable text
+
+### GitHub Authentication
+
+Token resolution (in priority order):
+
+1. `GITHUB_TOKEN` environment variable
+2. `GH_TOKEN` environment variable
+3. `gh auth token` CLI command
+
+Without a token, unauthenticated requests are used (60 requests/hour). When rate-limited, a helpful message is shown.
+
+### Examples
+
+```bash
+# check all tracked skills
+skillsdock check
+
+# machine-readable output
+skillsdock check --json
+
+# with authentication for higher rate limits
+GITHUB_TOKEN=ghp_xxx skillsdock check
+```
+
+### Text Output
+
+```
+✓ 3 skills up to date
+⚡ 2 skills have updates available:
+  - typescript-skill (vercel-labs/agent-skills)
+  - react-skill (vercel-labs/agent-skills)
+⏭ 1 skill skipped (no source URL)
+```
+
+### JSON Output
+
+```json
+{
+  "upToDate": [{ "name": "my-skill", "source": "owner/repo" }],
+  "updatesAvailable": [{ "name": "stale-skill", "source": "owner/repo", "currentHash": "...", "remoteHash": "..." }],
+  "skipped": [{ "name": "local-skill", "reason": "no source URL" }]
+}
+```
+
+## Update Command
+
+`skillsdock update` automatically re-installs skills that have available updates.
+
+### How It Works
+
+1. Runs the same freshness detection as `check`
+2. For each outdated skill, re-clones the source repository and re-installs the skill
+3. Updates `skills-lock.json` with the new content hash
+
+### Options
+
+- `--scope user|project` — Installation target (default: `project`)
+- `--dry-run` — Preview which skills would be updated without writing files
+
+### Examples
+
+```bash
+# update all outdated project-scope skills
+skillsdock update --scope project
+
+# preview what would be updated
+skillsdock update --dry-run
+
+# update user-scope skills
+skillsdock update --scope user
 ```
 
 ## Sync Modes

--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ Schema:
       "sourceType": "github",
       "sourceUrl": "https://github.com/owner/repo",
       "computedHash": "sha256-hex-string",
+      "treeSha": "sha256-hex-string",
       "skillPath": "relative/path/to/skill"
     }
   }
 }
 ```
+
+- `computedHash`: SHA-256 of local file contents (for integrity checking)
+- `treeSha`: SHA-256 fingerprint derived from git blob SHAs (for remote freshness detection via `skillsdock check`)
 
 The lockfile lives at `${projectRoot}/skills-lock.json` (auto-detected via `detectProjectRoot()`).
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ GITHUB_TOKEN=ghp_xxx skillsdock check
 
 ### Text Output
 
-```
+```text
 ✓ 3 skills up to date
 ⚡ 2 skills have updates available:
   - typescript-skill (vercel-labs/agent-skills)

--- a/bin/skillsdock-core.mjs
+++ b/bin/skillsdock-core.mjs
@@ -556,6 +556,8 @@ function mapExternalSkillLockEntry(skillName, entry) {
     sourceUrl: normalizeOptionalString(entry.sourceUrl),
     skillPath: normalizeOptionalString(entry.skillPath),
     skillFolderHash: normalizeOptionalString(entry.skillFolderHash),
+    treeSha: normalizeOptionalString(entry.treeSha),
+    repoSubpath: normalizeOptionalString(entry.repoSubpath),
     installedAt: normalizeIsoOrNull(entry.installedAt),
     updatedAt: normalizeIsoOrNull(entry.updatedAt),
     pluginName: normalizePluginName(entry.pluginName)
@@ -632,7 +634,7 @@ async function readExternalSkillLock(homeDir = HOME) {
 async function writeExternalSkillLock(lockPath, entries) {
   const skills = {};
   for (const entry of entries) {
-    skills[entry.skillName] = {
+    const obj = {
       source: entry.source || null,
       sourceType: entry.sourceType || null,
       sourceUrl: entry.sourceUrl || null,
@@ -642,6 +644,9 @@ async function writeExternalSkillLock(lockPath, entries) {
       updatedAt: entry.updatedAt || null,
       pluginName: entry.pluginName || null
     };
+    if (entry.treeSha) obj.treeSha = entry.treeSha;
+    if (entry.repoSubpath) obj.repoSubpath = entry.repoSubpath;
+    skills[entry.skillName] = obj;
   }
   const data = {
     version: EXTERNAL_SKILL_LOCK_VERSION,
@@ -4236,6 +4241,15 @@ async function cmdAdd(flags, args, context) {
           // Non-fatal
         }
 
+        let perSkillTreeSha = null;
+        if (repoRootDir && source.type === 'github') {
+          try {
+            perSkillTreeSha = computeLocalTreeFingerprint(repoRootDir, item.repoRelativeDir || '');
+          } catch {
+            // Non-fatal
+          }
+        }
+
         const entry = {
           skillName: item.skillName,
           source: sourceArg,
@@ -4247,6 +4261,8 @@ async function cmdAdd(flags, args, context) {
           updatedAt: now,
           pluginName: null
         };
+        if (perSkillTreeSha) entry.treeSha = perSkillTreeSha;
+        if (item.repoRelativeDir) entry.repoSubpath = item.repoRelativeDir;
 
         const idx = lockEntries.findIndex((e) => e.skillName === item.skillName);
         if (idx >= 0) {
@@ -5168,7 +5184,7 @@ function computeLocalTreeFingerprint(repoDir, subpath) {
 }
 
 async function checkSkillUpdates(lockSkills, registryItems, options = {}) {
-  const { fetchFn } = options;
+  const { fetchFn, userLockSkills } = options;
   const token = options.token !== undefined ? options.token : resolveGitHubToken();
 
   const upToDate = [];
@@ -5181,18 +5197,24 @@ async function checkSkillUpdates(lockSkills, registryItems, options = {}) {
     allEntries.push({ name, entry, scope: 'project' });
   }
 
+  if (userLockSkills && typeof userLockSkills === 'object') {
+    for (const [name, entry] of Object.entries(userLockSkills)) {
+      const existsAlready = allEntries.some((e) => e.name === name);
+      if (!existsAlready) {
+        allEntries.push({ name, entry, scope: 'registry' });
+      }
+    }
+  }
+
   if (registryItems && typeof registryItems === 'object') {
     for (const [key, item] of Object.entries(registryItems)) {
       if (item.externalSourceUrl && item.externalHash) {
         const registrySkillId = item.id || key;
         const registrySkillPath = item.externalSkillPath || item.skillPath || '';
-        const existsInLock = Object.entries(lockSkills).some(
-          ([lockName, e]) =>
-            e.sourceUrl === item.externalSourceUrl &&
-            (e.treeSha || e.computedHash) &&
-            (lockName === registrySkillId || e.skillPath === registrySkillPath)
+        const alreadyTracked = allEntries.some(
+          (e) => e.name === registrySkillId || (e.entry.skillPath && e.entry.skillPath === registrySkillPath)
         );
-        if (!existsInLock) {
+        if (!alreadyTracked) {
           allEntries.push({
             name: registrySkillId,
             entry: {
@@ -5305,6 +5327,7 @@ async function checkSkillUpdates(lockSkills, registryItems, options = {}) {
 async function cmdCheck(flags, context) {
   const jsonMode = Boolean(flags.json);
   const projectRoot = context.projectRoot;
+  const homeDir = context.homeDir || HOME;
   const fetchFn = context._fetchFn;
 
   const lockData = await readProjectLockfile(projectRoot);
@@ -5317,11 +5340,34 @@ async function cmdCheck(flags, context) {
     // Registry not available
   }
 
-  const result = await checkSkillUpdates(lockData.skills, registryItems, { fetchFn });
+  let userLockSkills = {};
+  try {
+    const extLock = await readExternalSkillLock(homeDir);
+    if (extLock.healthy && extLock.entriesByName.size > 0) {
+      for (const [name, entry] of extLock.entriesByName) {
+        if (entry.sourceUrl && entry.sourceType === 'github') {
+          userLockSkills[name] = {
+            source: entry.source,
+            sourceType: entry.sourceType,
+            sourceUrl: entry.sourceUrl,
+            computedHash: entry.skillFolderHash,
+            treeSha: entry.treeSha || null,
+            repoSubpath: entry.repoSubpath || null,
+            skillPath: entry.skillPath
+          };
+        }
+      }
+    }
+  } catch {
+    // External lock not available
+  }
+
+  const result = await checkSkillUpdates(lockData.skills, registryItems, { fetchFn, userLockSkills });
 
   if (
     Object.keys(lockData.skills).length === 0 &&
-    Object.keys(registryItems).length === 0
+    Object.keys(registryItems).length === 0 &&
+    Object.keys(userLockSkills).length === 0
   ) {
     if (jsonMode) {
       console.log(JSON.stringify({ upToDate: [], updatesAvailable: [], skipped: [] }, null, 2));
@@ -5388,14 +5434,41 @@ async function cmdUpdate(flags, args, context) {
     // Registry not available
   }
 
-  if (Object.keys(lockData.skills).length === 0 && Object.keys(registryItems).length === 0) {
+  let userLockSkills = {};
+  try {
+    const extLock = await readExternalSkillLock(homeDir);
+    if (extLock.healthy && extLock.entriesByName.size > 0) {
+      for (const [name, entry] of extLock.entriesByName) {
+        if (entry.sourceUrl && entry.sourceType === 'github') {
+          userLockSkills[name] = {
+            source: entry.source,
+            sourceType: entry.sourceType,
+            sourceUrl: entry.sourceUrl,
+            computedHash: entry.skillFolderHash,
+            treeSha: entry.treeSha || null,
+            repoSubpath: entry.repoSubpath || null,
+            skillPath: entry.skillPath
+          };
+        }
+      }
+    }
+  } catch {
+    // External lock not available
+  }
+
+  if (
+    Object.keys(lockData.skills).length === 0 &&
+    Object.keys(registryItems).length === 0 &&
+    Object.keys(userLockSkills).length === 0
+  ) {
     console.log("No tracked skills found. Use 'skillsdock add' to install skills first.");
     return;
   }
 
   const checkSkills = scope === 'project' ? lockData.skills : {};
   const checkRegistry = scope === 'user' ? registryItems : {};
-  const result = await checkSkillUpdates(checkSkills, checkRegistry, { fetchFn });
+  const checkUserLock = scope === 'user' ? userLockSkills : {};
+  const result = await checkSkillUpdates(checkSkills, checkRegistry, { fetchFn, userLockSkills: checkUserLock });
 
   const scopeFiltered = result.updatesAvailable.filter((u) => {
     if (scope === 'project') return u.scope === 'project';
@@ -5507,6 +5580,8 @@ async function cmdUpdate(flags, args, context) {
         }
         const now = new Date().toISOString();
         const existing = lockEntries.find((e) => e.skillName === u.name);
+        const repoDir = path.join(tmpDir, 'repo');
+        const skillRepoSubpath = path.relative(repoDir, match.skillDir) || null;
         const newEntry = {
           skillName: u.name,
           source: entry.source,
@@ -5518,6 +5593,8 @@ async function cmdUpdate(flags, args, context) {
           updatedAt: now,
           pluginName: existing?.pluginName || null
         };
+        if (newTreeSha) newEntry.treeSha = newTreeSha;
+        if (skillRepoSubpath) newEntry.repoSubpath = skillRepoSubpath;
         const idx = lockEntries.findIndex((e) => e.skillName === u.name);
         if (idx >= 0) {
           lockEntries[idx] = newEntry;

--- a/bin/skillsdock-core.mjs
+++ b/bin/skillsdock-core.mjs
@@ -4148,6 +4148,8 @@ async function cmdAdd(flags, args, context) {
       );
     }
 
+    const repoRootDir = tmpDir ? path.join(tmpDir, 'repo') : null;
+
     for (const skillEntry of filtered) {
       try {
         parseContentForFormat('skill-md', await fs.readFile(skillEntry.skillPath, 'utf8'), skillEntry.skillPath);
@@ -4156,6 +4158,10 @@ async function cmdAdd(flags, args, context) {
         continue;
       }
 
+      const repoRelativeDir = repoRootDir
+        ? path.relative(repoRootDir, skillEntry.skillDir)
+        : '';
+
       if (dryRun) {
         const destDir = path.join(targetBaseDir, skillEntry.skillName);
         console.log(`[dry-run] Would install ${skillEntry.skillName} -> ${destDir}`);
@@ -4163,7 +4169,8 @@ async function cmdAdd(flags, args, context) {
           skillName: skillEntry.skillName,
           destDir,
           action: 'copy',
-          links: []
+          links: [],
+          repoRelativeDir
         });
         continue;
       }
@@ -4183,7 +4190,8 @@ async function cmdAdd(flags, args, context) {
         skillName: skillEntry.skillName,
         destDir: result.destDir,
         action: result.action,
-        links
+        links,
+        repoRelativeDir
       });
     }
 
@@ -4253,16 +4261,7 @@ async function cmdAdd(flags, args, context) {
 
     if (!dryRun && scope === 'project') {
       const resolvedUrl = sourceUrl(source);
-
-      let treeSha = null;
-      if (tmpDir && source.type === 'github') {
-        try {
-          const repoDir = path.join(tmpDir, 'repo');
-          treeSha = computeLocalTreeFingerprint(repoDir, source.subpath || '');
-        } catch {
-          // Non-fatal
-        }
-      }
+      const repoDir = tmpDir ? path.join(tmpDir, 'repo') : null;
 
       for (const item of installed) {
         let folderHash = null;
@@ -4272,14 +4271,25 @@ async function cmdAdd(flags, args, context) {
           // Non-fatal
         }
 
+        let perSkillTreeSha = null;
+        if (repoDir && source.type === 'github') {
+          try {
+            const skillRepoPath = item.repoRelativeDir || '';
+            perSkillTreeSha = computeLocalTreeFingerprint(repoDir, skillRepoPath);
+          } catch {
+            // Non-fatal
+          }
+        }
+
         const lockEntry = {
           source: sourceArg,
           sourceType: source.type,
           sourceUrl: resolvedUrl,
           computedHash: folderHash,
-          skillPath: path.relative(projectRoot, item.destDir)
+          skillPath: path.relative(projectRoot, item.destDir),
+          repoSubpath: item.repoRelativeDir || null
         };
-        if (treeSha) lockEntry.treeSha = treeSha;
+        if (perSkillTreeSha) lockEntry.treeSha = perSkillTreeSha;
         await updateLockfileEntry(projectRoot, item.skillName, lockEntry);
       }
     }
@@ -5261,7 +5271,7 @@ async function checkSkillUpdates(lockSkills, registryItems, options = {}) {
     }
 
     for (const skill of group.skills) {
-      const subpath = skill.parsed.subpath || '';
+      const subpath = skill.entry.repoSubpath || skill.parsed.subpath || '';
       const remoteFingerprint = buildTreeFingerprint(treeData, subpath);
       const localTreeSha = skill.entry.treeSha;
 
@@ -5455,7 +5465,8 @@ async function cmdUpdate(flags, args, context) {
       let newTreeSha = null;
       try {
         const repoDir = path.join(tmpDir, 'repo');
-        newTreeSha = computeLocalTreeFingerprint(repoDir, source.subpath || '');
+        const skillRepoSubpath = path.relative(repoDir, match.skillDir);
+        newTreeSha = computeLocalTreeFingerprint(repoDir, skillRepoSubpath);
       } catch {
         // Non-fatal
       }
@@ -5474,12 +5485,14 @@ async function cmdUpdate(flags, args, context) {
       }
 
       if (scope === 'project') {
+        const repoDir = path.join(tmpDir, 'repo');
         const lockEntry = {
           source: entry.source,
           sourceType: entry.sourceType,
           sourceUrl: entry.sourceUrl,
           computedHash: folderHash,
-          skillPath: path.relative(projectRoot, destDir)
+          skillPath: path.relative(projectRoot, destDir),
+          repoSubpath: path.relative(repoDir, match.skillDir) || null
         };
         if (newTreeSha) lockEntry.treeSha = newTreeSha;
         await updateLockfileEntry(projectRoot, u.name, lockEntry);

--- a/bin/skillsdock-core.mjs
+++ b/bin/skillsdock-core.mjs
@@ -5059,8 +5059,30 @@ function resolveGitHubToken() {
 /*  check / update — skill freshness detection via GitHub Trees API    */
 /* ------------------------------------------------------------------ */
 
+async function fetchRepoDefaultBranch(owner, repo, token, fetchFn) {
+  const url = `https://api.github.com/repos/${owner}/${repo}`;
+  const headers = { 'User-Agent': 'skillsdock-cli', Accept: 'application/vnd.github+json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  const doFetch = fetchFn || globalThis.fetch;
+  const resp = await doFetch(url, { headers });
+  if (resp.status === 403 || resp.status === 429) {
+    const err = new Error('GitHub API rate limit reached. Set GITHUB_TOKEN for higher limits.');
+    err.rateLimited = true;
+    throw err;
+  }
+  if (!resp.ok) {
+    throw new Error(`GitHub API returned ${resp.status} for ${owner}/${repo}`);
+  }
+  const data = await resp.json();
+  return data.default_branch || 'main';
+}
+
 async function fetchGitHubTree(owner, repo, branch, token, fetchFn) {
-  const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch || 'main'}?recursive=1`;
+  let ref = branch;
+  if (!ref) {
+    ref = await fetchRepoDefaultBranch(owner, repo, token, fetchFn);
+  }
+  const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${ref}?recursive=1`;
   const headers = { 'User-Agent': 'skillsdock-cli', Accept: 'application/vnd.github+json' };
   if (token) headers['Authorization'] = `Bearer ${token}`;
   const doFetch = fetchFn || globalThis.fetch;
@@ -5108,17 +5130,23 @@ async function checkSkillUpdates(lockSkills, registryItems, options = {}) {
   if (registryItems && typeof registryItems === 'object') {
     for (const [key, item] of Object.entries(registryItems)) {
       if (item.externalSourceUrl && item.externalHash) {
-        const existsInLock = Object.values(lockSkills).some(
-          (e) => e.sourceUrl === item.externalSourceUrl && e.computedHash
+        const registrySkillId = item.id || key;
+        const registrySkillPath = item.externalSkillPath || item.skillPath || '';
+        const existsInLock = Object.entries(lockSkills).some(
+          ([lockName, e]) =>
+            e.sourceUrl === item.externalSourceUrl &&
+            e.computedHash &&
+            (lockName === registrySkillId || e.skillPath === registrySkillPath)
         );
         if (!existsInLock) {
           allEntries.push({
-            name: item.id || key,
+            name: registrySkillId,
             entry: {
               source: item.externalSource,
               sourceType: item.externalSourceType,
               sourceUrl: item.externalSourceUrl,
-              computedHash: item.externalHash
+              computedHash: item.externalHash,
+              skillPath: registrySkillPath
             },
             scope: 'registry'
           });
@@ -5153,15 +5181,17 @@ async function checkSkillUpdates(lockSkills, registryItems, options = {}) {
       continue;
     }
 
-    if (!repoGroups.has(ownerRepo)) {
-      repoGroups.set(ownerRepo, { parsed, skills: [] });
+    const groupKey = `${ownerRepo}#${parsed.branch || ''}`;
+    if (!repoGroups.has(groupKey)) {
+      repoGroups.set(groupKey, { parsed, ownerRepo, skills: [] });
     }
-    repoGroups.get(ownerRepo).skills.push({ name, entry, parsed, scope: item.scope });
+    repoGroups.get(groupKey).skills.push({ name, entry, parsed, scope: item.scope });
   }
 
   skipped.push(...noSource);
 
-  for (const [ownerRepo, group] of repoGroups) {
+  for (const [, group] of repoGroups) {
+    const { ownerRepo } = group;
     let treeData;
     try {
       treeData = await fetchGitHubTree(
@@ -5299,9 +5329,17 @@ async function cmdUpdate(flags, args, context) {
     return;
   }
 
-  const result = await checkSkillUpdates(lockData.skills, registryItems, { fetchFn });
+  const checkSkills = scope === 'project' ? lockData.skills : {};
+  const checkRegistry = scope === 'user' ? registryItems : {};
+  const result = await checkSkillUpdates(checkSkills, checkRegistry, { fetchFn });
 
-  if (result.updatesAvailable.length === 0) {
+  const scopeFiltered = result.updatesAvailable.filter((u) => {
+    if (scope === 'project') return u.scope === 'project';
+    if (scope === 'user') return u.scope === 'registry';
+    return true;
+  });
+
+  if (scopeFiltered.length === 0) {
     const msg = `${result.upToDate.length} skill${result.upToDate.length === 1 ? '' : 's'} already up to date`;
     if (result.skipped.length > 0) {
       console.log(`${msg}, ${result.skipped.length} skipped.`);
@@ -5312,8 +5350,8 @@ async function cmdUpdate(flags, args, context) {
   }
 
   if (dryRun) {
-    console.log(`[dry-run] Would update ${result.updatesAvailable.length} skill(s):`);
-    for (const u of result.updatesAvailable) {
+    console.log(`[dry-run] Would update ${scopeFiltered.length} skill(s):`);
+    for (const u of scopeFiltered) {
       console.log(`  - ${u.name} (${u.source})`);
     }
     console.log(`\nUpdated 0 skills, ${result.upToDate.length} already up to date, ${result.skipped.length} skipped`);
@@ -5327,7 +5365,7 @@ async function cmdUpdate(flags, args, context) {
 
   let updatedCount = 0;
 
-  for (const u of result.updatesAvailable) {
+  for (const u of scopeFiltered) {
     const entry = u.entry;
     let source;
     try {
@@ -5349,23 +5387,68 @@ async function cmdUpdate(flags, args, context) {
         continue;
       }
 
-      await installSkillToTarget(match, targetBaseDir, { dryRun: false, useCopy: true });
+      const stagingDir = path.join(targetBaseDir, `.staging-${u.name}-${process.pid}-${Date.now()}`);
+      await installSkillToTarget(match, stagingDir, { dryRun: false, useCopy: true });
 
-      const destDir = path.join(targetBaseDir, u.name);
+      const stagedSkillDir = path.join(stagingDir, u.name);
       let folderHash = null;
       try {
-        folderHash = await computeSkillFolderHash(destDir);
+        folderHash = await computeSkillFolderHash(stagedSkillDir);
       } catch {
         // Non-fatal
       }
 
-      await updateLockfileEntry(projectRoot, u.name, {
-        source: entry.source,
-        sourceType: entry.sourceType,
-        sourceUrl: entry.sourceUrl,
-        computedHash: folderHash,
-        skillPath: path.relative(projectRoot, destDir)
-      });
+      const destDir = path.join(targetBaseDir, u.name);
+      try {
+        await fs.rm(destDir, { recursive: true, force: true });
+      } catch (rmErr) {
+        if (rmErr?.code !== 'ENOENT') throw rmErr;
+      }
+      await fs.rename(stagedSkillDir, destDir);
+      try {
+        await fs.rm(stagingDir, { recursive: true, force: true });
+      } catch {
+        // staging parent cleanup, best-effort
+      }
+
+      if (scope === 'project') {
+        await updateLockfileEntry(projectRoot, u.name, {
+          source: entry.source,
+          sourceType: entry.sourceType,
+          sourceUrl: entry.sourceUrl,
+          computedHash: folderHash,
+          skillPath: path.relative(projectRoot, destDir)
+        });
+      } else {
+        const lockPath = getExternalSkillLockPath(homeDir);
+        const existingLock = await readExternalSkillLock(homeDir);
+        const lockEntries = [];
+        if (existingLock.healthy) {
+          for (const [, le] of existingLock.entriesByName) {
+            lockEntries.push(le);
+          }
+        }
+        const now = new Date().toISOString();
+        const existing = lockEntries.find((e) => e.skillName === u.name);
+        const newEntry = {
+          skillName: u.name,
+          source: entry.source,
+          sourceType: entry.sourceType,
+          sourceUrl: entry.sourceUrl,
+          skillPath: `${u.name}/SKILL.md`,
+          skillFolderHash: folderHash,
+          installedAt: existing?.installedAt || now,
+          updatedAt: now,
+          pluginName: existing?.pluginName || null
+        };
+        const idx = lockEntries.findIndex((e) => e.skillName === u.name);
+        if (idx >= 0) {
+          lockEntries[idx] = newEntry;
+        } else {
+          lockEntries.push(newEntry);
+        }
+        await writeExternalSkillLock(lockPath, lockEntries);
+      }
 
       updatedCount++;
       console.log(`  Updated: ${u.name} (${u.source})`);

--- a/bin/skillsdock-core.mjs
+++ b/bin/skillsdock-core.mjs
@@ -4,7 +4,7 @@ import fsSync from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
-import { spawnSync } from 'node:child_process';
+import { spawnSync, execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import matter from 'gray-matter';
 
@@ -1899,6 +1899,8 @@ Usage:
   skillsdock remove --all --scope <user|project> [--dry-run] [--force]
   skillsdock add <source> [--scope user|project] [--dry-run] [--copy]
   skillsdock sync --from node_modules [--scope user|project] [--dry-run]
+  skillsdock check [--json]
+  skillsdock update [--scope user|project] [--dry-run]
   skillsdock doctor [--config <path>] [--registry <path>] [--agents] [--skills-spec]
   skillsdock version
 
@@ -1915,6 +1917,10 @@ Examples:
   skillsdock add owner/repo@skill-name --dry-run
   skillsdock add ./path/to/skills --scope project
   skillsdock sync --from node_modules --dry-run
+  skillsdock check
+  skillsdock check --json
+  skillsdock update --scope project
+  skillsdock update --dry-run
 `);
 }
 
@@ -5030,6 +5036,357 @@ async function cmdSyncFromNodeModules(flags, context) {
   );
 }
 
+/* ------------------------------------------------------------------ */
+/*  GitHub Token Resolution                                            */
+/* ------------------------------------------------------------------ */
+
+function resolveGitHubToken() {
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
+  if (process.env.GH_TOKEN) return process.env.GH_TOKEN;
+  try {
+    const result = spawnSync('gh', ['auth', 'token'], { encoding: 'utf8', timeout: 5000 });
+    if (result.status === 0 && result.stdout) {
+      const token = result.stdout.trim();
+      if (token.length > 0) return token;
+    }
+  } catch {
+    // gh CLI not available
+  }
+  return null;
+}
+
+/* ------------------------------------------------------------------ */
+/*  check / update — skill freshness detection via GitHub Trees API    */
+/* ------------------------------------------------------------------ */
+
+async function fetchGitHubTree(owner, repo, branch, token, fetchFn) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch || 'main'}?recursive=1`;
+  const headers = { 'User-Agent': 'skillsdock-cli', Accept: 'application/vnd.github+json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  const doFetch = fetchFn || globalThis.fetch;
+  const resp = await doFetch(url, { headers });
+  if (resp.status === 403 || resp.status === 429) {
+    const err = new Error('GitHub API rate limit reached. Set GITHUB_TOKEN for higher limits.');
+    err.rateLimited = true;
+    throw err;
+  }
+  if (!resp.ok) {
+    throw new Error(`GitHub API returned ${resp.status} for ${owner}/${repo}`);
+  }
+  return resp.json();
+}
+
+function buildTreeFingerprint(treeData, subpath) {
+  const prefix = subpath ? (subpath.endsWith('/') ? subpath : subpath + '/') : '';
+  const relevant = treeData.tree.filter((entry) => {
+    if (!prefix) return true;
+    return entry.path === subpath || entry.path.startsWith(prefix);
+  });
+  relevant.sort((a, b) => a.path.localeCompare(b.path));
+  const hash = crypto.createHash('sha256');
+  for (const entry of relevant) {
+    hash.update(entry.path);
+    hash.update(entry.sha || '');
+  }
+  return hash.digest('hex');
+}
+
+async function checkSkillUpdates(lockSkills, registryItems, options = {}) {
+  const { fetchFn } = options;
+  const token = options.token !== undefined ? options.token : resolveGitHubToken();
+
+  const upToDate = [];
+  const updatesAvailable = [];
+  const skipped = [];
+
+  const allEntries = [];
+
+  for (const [name, entry] of Object.entries(lockSkills)) {
+    allEntries.push({ name, entry, scope: 'project' });
+  }
+
+  if (registryItems && typeof registryItems === 'object') {
+    for (const [key, item] of Object.entries(registryItems)) {
+      if (item.externalSourceUrl && item.externalHash) {
+        const existsInLock = Object.values(lockSkills).some(
+          (e) => e.sourceUrl === item.externalSourceUrl && e.computedHash
+        );
+        if (!existsInLock) {
+          allEntries.push({
+            name: item.id || key,
+            entry: {
+              source: item.externalSource,
+              sourceType: item.externalSourceType,
+              sourceUrl: item.externalSourceUrl,
+              computedHash: item.externalHash
+            },
+            scope: 'registry'
+          });
+        }
+      }
+    }
+  }
+
+  const repoGroups = new Map();
+  const noSource = [];
+
+  for (const item of allEntries) {
+    const { name, entry } = item;
+    if (!entry.sourceUrl || !entry.computedHash) {
+      noSource.push({ name, reason: 'no source URL' });
+      continue;
+    }
+    if (entry.sourceType !== 'github') {
+      skipped.push({ name, reason: `non-GitHub source (${entry.sourceType || 'unknown'})` });
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = parseSource(entry.source || entry.sourceUrl);
+    } catch {
+      skipped.push({ name, reason: 'unparseable source' });
+      continue;
+    }
+    const ownerRepo = getOwnerRepo(parsed);
+    if (!ownerRepo) {
+      skipped.push({ name, reason: 'no owner/repo' });
+      continue;
+    }
+
+    if (!repoGroups.has(ownerRepo)) {
+      repoGroups.set(ownerRepo, { parsed, skills: [] });
+    }
+    repoGroups.get(ownerRepo).skills.push({ name, entry, parsed, scope: item.scope });
+  }
+
+  skipped.push(...noSource);
+
+  for (const [ownerRepo, group] of repoGroups) {
+    let treeData;
+    try {
+      treeData = await fetchGitHubTree(
+        group.parsed.owner,
+        group.parsed.repo,
+        group.parsed.branch,
+        token,
+        fetchFn
+      );
+    } catch (err) {
+      if (err.rateLimited) {
+        for (const skill of group.skills) {
+          skipped.push({ name: skill.name, reason: 'rate limited' });
+        }
+        console.warn(err.message);
+        continue;
+      }
+      for (const skill of group.skills) {
+        skipped.push({ name: skill.name, reason: `network error: ${err.message}` });
+      }
+      console.warn(`Warning: Could not fetch tree for ${ownerRepo}: ${err.message}`);
+      continue;
+    }
+
+    for (const skill of group.skills) {
+      const subpath = skill.parsed.subpath || '';
+      const remoteFingerprint = buildTreeFingerprint(treeData, subpath);
+
+      if (remoteFingerprint === skill.entry.computedHash) {
+        upToDate.push({ name: skill.name, source: ownerRepo });
+      } else {
+        updatesAvailable.push({
+          name: skill.name,
+          source: ownerRepo,
+          currentHash: skill.entry.computedHash,
+          remoteHash: remoteFingerprint,
+          entry: skill.entry,
+          scope: skill.scope
+        });
+      }
+    }
+  }
+
+  return { upToDate, updatesAvailable, skipped };
+}
+
+async function cmdCheck(flags, context) {
+  const jsonMode = Boolean(flags.json);
+  const projectRoot = context.projectRoot;
+  const fetchFn = context._fetchFn;
+
+  const lockData = await readProjectLockfile(projectRoot);
+
+  let registryItems = {};
+  try {
+    const { registry } = await loadRegistry(flags.registry);
+    registryItems = registry.items || {};
+  } catch {
+    // Registry not available
+  }
+
+  const result = await checkSkillUpdates(lockData.skills, registryItems, { fetchFn });
+
+  if (
+    Object.keys(lockData.skills).length === 0 &&
+    Object.keys(registryItems).length === 0
+  ) {
+    if (jsonMode) {
+      console.log(JSON.stringify({ upToDate: [], updatesAvailable: [], skipped: [] }, null, 2));
+    } else {
+      console.log("No tracked skills found. Use 'skillsdock add' to install skills first.");
+    }
+    return result;
+  }
+
+  if (jsonMode) {
+    const output = {
+      upToDate: result.upToDate,
+      updatesAvailable: result.updatesAvailable.map((u) => ({
+        name: u.name,
+        source: u.source,
+        currentHash: u.currentHash,
+        remoteHash: u.remoteHash
+      })),
+      skipped: result.skipped
+    };
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    if (result.upToDate.length > 0) {
+      console.log(`\u2713 ${result.upToDate.length} skill${result.upToDate.length === 1 ? '' : 's'} up to date`);
+    }
+    if (result.updatesAvailable.length > 0) {
+      console.log(
+        `\u26A1 ${result.updatesAvailable.length} skill${result.updatesAvailable.length === 1 ? '' : 's'} ha${result.updatesAvailable.length === 1 ? 's' : 've'} updates available:`
+      );
+      for (const u of result.updatesAvailable) {
+        console.log(`  - ${u.name} (${u.source})`);
+      }
+    }
+    if (result.skipped.length > 0) {
+      console.log(
+        `\u23ED ${result.skipped.length} skill${result.skipped.length === 1 ? '' : 's'} skipped (${result.skipped.map((s) => s.reason).filter((v, i, a) => a.indexOf(v) === i).join(', ')})`
+      );
+    }
+    if (result.upToDate.length === 0 && result.updatesAvailable.length === 0 && result.skipped.length === 0) {
+      console.log("No tracked skills found. Use 'skillsdock add' to install skills first.");
+    }
+  }
+
+  return result;
+}
+
+async function cmdUpdate(flags, args, context) {
+  const dryRun = Boolean(flags['dry-run'] || flags.dryRun);
+  const scope = typeof flags.scope === 'string' ? flags.scope : 'project';
+  if (!VALID_SCOPE_SET.has(scope)) {
+    throw makeCliError(`Invalid --scope "${scope}". Use --scope user|project.`);
+  }
+  const projectRoot = context.projectRoot;
+  const homeDir = context.homeDir || HOME;
+  const fetchFn = context._fetchFn;
+
+  const lockData = await readProjectLockfile(projectRoot);
+
+  let registryItems = {};
+  try {
+    const { registry } = await loadRegistry(flags.registry);
+    registryItems = registry.items || {};
+  } catch {
+    // Registry not available
+  }
+
+  if (Object.keys(lockData.skills).length === 0 && Object.keys(registryItems).length === 0) {
+    console.log("No tracked skills found. Use 'skillsdock add' to install skills first.");
+    return;
+  }
+
+  const result = await checkSkillUpdates(lockData.skills, registryItems, { fetchFn });
+
+  if (result.updatesAvailable.length === 0) {
+    const msg = `${result.upToDate.length} skill${result.upToDate.length === 1 ? '' : 's'} already up to date`;
+    if (result.skipped.length > 0) {
+      console.log(`${msg}, ${result.skipped.length} skipped.`);
+    } else {
+      console.log(`${msg}.`);
+    }
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`[dry-run] Would update ${result.updatesAvailable.length} skill(s):`);
+    for (const u of result.updatesAvailable) {
+      console.log(`  - ${u.name} (${u.source})`);
+    }
+    console.log(`\nUpdated 0 skills, ${result.upToDate.length} already up to date, ${result.skipped.length} skipped`);
+    return;
+  }
+
+  const targetBaseDir =
+    scope === 'project'
+      ? path.join(projectRoot, UNIVERSAL_CANONICAL_DIR)
+      : path.resolve(expandHomePath(`~/${UNIVERSAL_CANONICAL_DIR}`, homeDir));
+
+  let updatedCount = 0;
+
+  for (const u of result.updatesAvailable) {
+    const entry = u.entry;
+    let source;
+    try {
+      source = parseSource(entry.source || entry.sourceUrl);
+    } catch (err) {
+      console.warn(`Warning: Could not parse source for ${u.name}: ${err.message}`);
+      continue;
+    }
+
+    let tmpDir = null;
+    try {
+      tmpDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'skillsdock-update-'));
+      const searchRoot = await cloneGitRepo(source, tmpDir);
+      const skills = await discoverSkillMdFiles(searchRoot);
+
+      const match = skills.find((s) => s.skillName === u.name);
+      if (!match) {
+        console.warn(`Warning: Skill "${u.name}" not found in re-cloned repository ${u.source}`);
+        continue;
+      }
+
+      await installSkillToTarget(match, targetBaseDir, { dryRun: false, useCopy: true });
+
+      const destDir = path.join(targetBaseDir, u.name);
+      let folderHash = null;
+      try {
+        folderHash = await computeSkillFolderHash(destDir);
+      } catch {
+        // Non-fatal
+      }
+
+      await updateLockfileEntry(projectRoot, u.name, {
+        source: entry.source,
+        sourceType: entry.sourceType,
+        sourceUrl: entry.sourceUrl,
+        computedHash: folderHash,
+        skillPath: path.relative(projectRoot, destDir)
+      });
+
+      updatedCount++;
+      console.log(`  Updated: ${u.name} (${u.source})`);
+    } catch (err) {
+      console.warn(`Warning: Failed to update ${u.name}: ${err.message}`);
+    } finally {
+      if (tmpDir) {
+        try {
+          fsSync.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+    }
+  }
+
+  console.log(
+    `\nUpdated ${updatedCount} skill${updatedCount === 1 ? '' : 's'}, ${result.upToDate.length} already up to date, ${result.skipped.length} skipped`
+  );
+}
+
 export async function runCli(argv = process.argv.slice(2), options = {}) {
   const { flags, positional } = parseArgs(argv);
   const command = positional[0];
@@ -5097,6 +5454,14 @@ export async function runCli(argv = process.argv.slice(2), options = {}) {
     await cmdRemove(flags, args, context);
     return;
   }
+  if (command === 'check') {
+    await cmdCheck(flags, context);
+    return;
+  }
+  if (command === 'update') {
+    await cmdUpdate(flags, args, context);
+    return;
+  }
 
   throw new Error(`Unknown command: ${command}`);
 }
@@ -5107,12 +5472,16 @@ export {
   buildDefaultConfig,
   buildDoctorAgentMatrixRows,
   buildCleanupPlan,
+  checkSkillUpdates,
+  cmdCheck,
   cmdRemove,
+  cmdUpdate,
   computeSkillFolderHash,
   convertContentToFormat,
   detectProjectRoot,
   discoverNodeModuleSkills,
   getOwnerRepo,
+  installSkillToTarget,
   normalizeRegistry,
   normalizeConfigV2,
   parseContentForFormat,
@@ -5120,6 +5489,7 @@ export {
   planSyncWriteMode,
   readProjectLockfile,
   removeLockfileEntry,
+  resolveGitHubToken,
   resolveSelectorMatches,
   resolveSyncTarget,
   resolveTemplatePath,

--- a/bin/skillsdock-core.mjs
+++ b/bin/skillsdock-core.mjs
@@ -4251,6 +4251,16 @@ async function cmdAdd(flags, args, context) {
     if (!dryRun && scope === 'project') {
       const resolvedUrl = sourceUrl(source);
 
+      let treeSha = null;
+      if (tmpDir && source.type === 'github') {
+        try {
+          const repoDir = path.join(tmpDir, 'repo');
+          treeSha = computeLocalTreeFingerprint(repoDir, source.subpath || '');
+        } catch {
+          // Non-fatal
+        }
+      }
+
       for (const item of installed) {
         let folderHash = null;
         try {
@@ -4259,13 +4269,15 @@ async function cmdAdd(flags, args, context) {
           // Non-fatal
         }
 
-        await updateLockfileEntry(projectRoot, item.skillName, {
+        const lockEntry = {
           source: sourceArg,
           sourceType: source.type,
           sourceUrl: resolvedUrl,
           computedHash: folderHash,
           skillPath: path.relative(projectRoot, item.destDir)
-        });
+        };
+        if (treeSha) lockEntry.treeSha = treeSha;
+        await updateLockfileEntry(projectRoot, item.skillName, lockEntry);
       }
     }
 
@@ -5100,15 +5112,44 @@ async function fetchGitHubTree(owner, repo, branch, token, fetchFn) {
 
 function buildTreeFingerprint(treeData, subpath) {
   const prefix = subpath ? (subpath.endsWith('/') ? subpath : subpath + '/') : '';
-  const relevant = treeData.tree.filter((entry) => {
-    if (!prefix) return true;
-    return entry.path === subpath || entry.path.startsWith(prefix);
-  });
+  const relevant = treeData.tree
+    .filter((entry) => {
+      if (entry.type !== 'blob') return false;
+      if (!prefix) return true;
+      return entry.path === subpath || entry.path.startsWith(prefix);
+    });
   relevant.sort((a, b) => a.path.localeCompare(b.path));
   const hash = crypto.createHash('sha256');
   for (const entry of relevant) {
     hash.update(entry.path);
     hash.update(entry.sha || '');
+  }
+  return hash.digest('hex');
+}
+
+function computeLocalTreeFingerprint(repoDir, subpath) {
+  const result = spawnSync('git', ['ls-tree', '-r', 'HEAD'], {
+    cwd: repoDir,
+    encoding: 'utf8',
+    timeout: 10000
+  });
+  if (result.status !== 0) return null;
+
+  const prefix = subpath ? (subpath.endsWith('/') ? subpath : subpath + '/') : '';
+  const lines = result.stdout.trim().split('\n').filter(Boolean);
+  const entries = [];
+  for (const line of lines) {
+    const match = line.match(/^\d+ blob ([0-9a-f]+)\t(.+)$/);
+    if (!match) continue;
+    const [, sha, filePath] = match;
+    if (prefix && filePath !== subpath && !filePath.startsWith(prefix)) continue;
+    entries.push({ path: filePath, sha });
+  }
+  entries.sort((a, b) => a.path.localeCompare(b.path));
+  const hash = crypto.createHash('sha256');
+  for (const entry of entries) {
+    hash.update(entry.path);
+    hash.update(entry.sha);
   }
   return hash.digest('hex');
 }
@@ -5135,7 +5176,7 @@ async function checkSkillUpdates(lockSkills, registryItems, options = {}) {
         const existsInLock = Object.entries(lockSkills).some(
           ([lockName, e]) =>
             e.sourceUrl === item.externalSourceUrl &&
-            e.computedHash &&
+            (e.treeSha || e.computedHash) &&
             (lockName === registrySkillId || e.skillPath === registrySkillPath)
         );
         if (!existsInLock) {
@@ -5160,7 +5201,7 @@ async function checkSkillUpdates(lockSkills, registryItems, options = {}) {
 
   for (const item of allEntries) {
     const { name, entry } = item;
-    if (!entry.sourceUrl || !entry.computedHash) {
+    if (!entry.sourceUrl) {
       noSource.push({ name, reason: 'no source URL' });
       continue;
     }
@@ -5219,14 +5260,24 @@ async function checkSkillUpdates(lockSkills, registryItems, options = {}) {
     for (const skill of group.skills) {
       const subpath = skill.parsed.subpath || '';
       const remoteFingerprint = buildTreeFingerprint(treeData, subpath);
+      const localTreeSha = skill.entry.treeSha;
 
-      if (remoteFingerprint === skill.entry.computedHash) {
+      if (!localTreeSha) {
+        updatesAvailable.push({
+          name: skill.name,
+          source: ownerRepo,
+          currentHash: null,
+          remoteHash: remoteFingerprint,
+          entry: skill.entry,
+          scope: skill.scope
+        });
+      } else if (remoteFingerprint === localTreeSha) {
         upToDate.push({ name: skill.name, source: ownerRepo });
       } else {
         updatesAvailable.push({
           name: skill.name,
           source: ownerRepo,
-          currentHash: skill.entry.computedHash,
+          currentHash: localTreeSha,
           remoteHash: remoteFingerprint,
           entry: skill.entry,
           scope: skill.scope
@@ -5398,6 +5449,14 @@ async function cmdUpdate(flags, args, context) {
         // Non-fatal
       }
 
+      let newTreeSha = null;
+      try {
+        const repoDir = path.join(tmpDir, 'repo');
+        newTreeSha = computeLocalTreeFingerprint(repoDir, source.subpath || '');
+      } catch {
+        // Non-fatal
+      }
+
       const destDir = path.join(targetBaseDir, u.name);
       try {
         await fs.rm(destDir, { recursive: true, force: true });
@@ -5412,13 +5471,15 @@ async function cmdUpdate(flags, args, context) {
       }
 
       if (scope === 'project') {
-        await updateLockfileEntry(projectRoot, u.name, {
+        const lockEntry = {
           source: entry.source,
           sourceType: entry.sourceType,
           sourceUrl: entry.sourceUrl,
           computedHash: folderHash,
           skillPath: path.relative(projectRoot, destDir)
-        });
+        };
+        if (newTreeSha) lockEntry.treeSha = newTreeSha;
+        await updateLockfileEntry(projectRoot, u.name, lockEntry);
       } else {
         const lockPath = getExternalSkillLockPath(homeDir);
         const existingLock = await readExternalSkillLock(homeDir);
@@ -5559,6 +5620,7 @@ export {
   cmdCheck,
   cmdRemove,
   cmdUpdate,
+  computeLocalTreeFingerprint,
   computeSkillFolderHash,
   convertContentToFormat,
   detectProjectRoot,

--- a/test/check-update.test.mjs
+++ b/test/check-update.test.mjs
@@ -1,0 +1,757 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  checkSkillUpdates,
+  cmdCheck,
+  cmdUpdate,
+  readProjectLockfile,
+  writeProjectLockfile,
+  resolveGitHubToken,
+  detectProjectRoot
+} from '../bin/skillsdock-core.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(repoRoot, 'bin', 'skillsdock.mjs');
+
+async function makeTmpDir() {
+  return mkdtemp(path.join(tmpdir(), 'skillsdock-test-'));
+}
+
+async function initGitRepo(dir) {
+  spawnSync('git', ['init', dir], { encoding: 'utf8' });
+  spawnSync('git', ['-C', dir, 'config', 'user.email', 'test@test.com'], { encoding: 'utf8' });
+  spawnSync('git', ['-C', dir, 'config', 'user.name', 'Test'], { encoding: 'utf8' });
+  await writeFile(path.join(dir, '.gitkeep'), '', 'utf8');
+  spawnSync('git', ['-C', dir, 'add', '.'], { encoding: 'utf8' });
+  spawnSync('git', ['-C', dir, 'commit', '-m', 'init'], { encoding: 'utf8' });
+}
+
+function makeFetchFn(treeResponse) {
+  return async (url, opts) => {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => treeResponse
+    };
+  };
+}
+
+function makeFailingFetchFn(status = 500, message = 'Internal Server Error') {
+  return async (url, opts) => {
+    return {
+      ok: false,
+      status,
+      json: async () => ({ message })
+    };
+  };
+}
+
+function makeRateLimitFetchFn() {
+  return async (url, opts) => {
+    return {
+      ok: false,
+      status: 403,
+      json: async () => ({ message: 'rate limit exceeded' })
+    };
+  };
+}
+
+const MOCK_TREE = {
+  sha: 'abc123',
+  tree: [
+    { path: 'SKILL.md', type: 'blob', sha: 'file-sha-1' },
+    { path: 'index.js', type: 'blob', sha: 'file-sha-2' },
+    { path: 'lib', type: 'tree', sha: 'dir-sha-1' },
+    { path: 'lib/helper.js', type: 'blob', sha: 'file-sha-3' }
+  ]
+};
+
+const UPDATED_TREE = {
+  sha: 'def456',
+  tree: [
+    { path: 'SKILL.md', type: 'blob', sha: 'changed-sha-1' },
+    { path: 'index.js', type: 'blob', sha: 'file-sha-2' },
+    { path: 'lib', type: 'tree', sha: 'dir-sha-1' },
+    { path: 'lib/helper.js', type: 'blob', sha: 'file-sha-3' },
+    { path: 'lib/new-file.js', type: 'blob', sha: 'file-sha-4' }
+  ]
+};
+
+import crypto from 'node:crypto';
+
+function computeTreeFingerprint(treeData, subpath) {
+  const prefix = subpath ? (subpath.endsWith('/') ? subpath : subpath + '/') : '';
+  const relevant = treeData.tree.filter((entry) => {
+    if (!prefix) return true;
+    return entry.path === subpath || entry.path.startsWith(prefix);
+  });
+  relevant.sort((a, b) => a.path.localeCompare(b.path));
+  const hash = crypto.createHash('sha256');
+  for (const entry of relevant) {
+    hash.update(entry.path);
+    hash.update(entry.sha || '');
+  }
+  return hash.digest('hex');
+}
+
+// --- resolveGitHubToken tests ---
+
+test('resolveGitHubToken returns GITHUB_TOKEN when set', () => {
+  const origGH = process.env.GITHUB_TOKEN;
+  const origGHT = process.env.GH_TOKEN;
+  try {
+    process.env.GITHUB_TOKEN = 'test-github-token';
+    process.env.GH_TOKEN = 'test-gh-token';
+    const token = resolveGitHubToken();
+    assert.equal(token, 'test-github-token');
+  } finally {
+    if (origGH !== undefined) process.env.GITHUB_TOKEN = origGH;
+    else delete process.env.GITHUB_TOKEN;
+    if (origGHT !== undefined) process.env.GH_TOKEN = origGHT;
+    else delete process.env.GH_TOKEN;
+  }
+});
+
+test('resolveGitHubToken falls back to GH_TOKEN when GITHUB_TOKEN not set', () => {
+  const origGH = process.env.GITHUB_TOKEN;
+  const origGHT = process.env.GH_TOKEN;
+  try {
+    delete process.env.GITHUB_TOKEN;
+    process.env.GH_TOKEN = 'test-gh-token';
+    const token = resolveGitHubToken();
+    assert.equal(token, 'test-gh-token');
+  } finally {
+    if (origGH !== undefined) process.env.GITHUB_TOKEN = origGH;
+    else delete process.env.GITHUB_TOKEN;
+    if (origGHT !== undefined) process.env.GH_TOKEN = origGHT;
+    else delete process.env.GH_TOKEN;
+  }
+});
+
+test('resolveGitHubToken returns null when no token available', () => {
+  const origGH = process.env.GITHUB_TOKEN;
+  const origGHT = process.env.GH_TOKEN;
+  try {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    const token = resolveGitHubToken();
+    assert.ok(token === null || typeof token === 'string');
+  } finally {
+    if (origGH !== undefined) process.env.GITHUB_TOKEN = origGH;
+    else delete process.env.GITHUB_TOKEN;
+    if (origGHT !== undefined) process.env.GH_TOKEN = origGHT;
+    else delete process.env.GH_TOKEN;
+  }
+});
+
+// --- checkSkillUpdates tests ---
+
+test('checkSkillUpdates detects updates available', async () => {
+  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+  const lockSkills = {
+    'my-skill': {
+      source: 'test-owner/test-repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/test-owner/test-repo',
+      computedHash: currentFingerprint,
+      skillPath: '.agents/skills/my-skill'
+    }
+  };
+
+  const result = await checkSkillUpdates(lockSkills, {}, {
+    fetchFn: makeFetchFn(UPDATED_TREE),
+    token: null
+  });
+
+  assert.equal(result.updatesAvailable.length, 1);
+  assert.equal(result.updatesAvailable[0].name, 'my-skill');
+  assert.equal(result.upToDate.length, 0);
+});
+
+test('checkSkillUpdates reports up-to-date when hashes match', async () => {
+  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+  const lockSkills = {
+    'my-skill': {
+      source: 'test-owner/test-repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/test-owner/test-repo',
+      computedHash: currentFingerprint,
+      skillPath: '.agents/skills/my-skill'
+    }
+  };
+
+  const result = await checkSkillUpdates(lockSkills, {}, {
+    fetchFn: makeFetchFn(MOCK_TREE),
+    token: null
+  });
+
+  assert.equal(result.upToDate.length, 1);
+  assert.equal(result.upToDate[0].name, 'my-skill');
+  assert.equal(result.updatesAvailable.length, 0);
+});
+
+test('checkSkillUpdates skips skills with no source URL', async () => {
+  const lockSkills = {
+    'local-skill': {
+      source: './local/path',
+      sourceType: 'local',
+      sourceUrl: null,
+      computedHash: 'abc123',
+      skillPath: '.agents/skills/local-skill'
+    }
+  };
+
+  const result = await checkSkillUpdates(lockSkills, {}, {
+    fetchFn: makeFetchFn(MOCK_TREE),
+    token: null
+  });
+
+  assert.equal(result.skipped.length, 1);
+  assert.equal(result.skipped[0].name, 'local-skill');
+  assert.equal(result.skipped[0].reason, 'no source URL');
+});
+
+test('checkSkillUpdates skips non-GitHub sources', async () => {
+  const lockSkills = {
+    'gitlab-skill': {
+      source: 'gitlab:owner/repo',
+      sourceType: 'gitlab',
+      sourceUrl: 'https://gitlab.com/owner/repo',
+      computedHash: 'abc123',
+      skillPath: '.agents/skills/gitlab-skill'
+    }
+  };
+
+  const result = await checkSkillUpdates(lockSkills, {}, {
+    fetchFn: makeFetchFn(MOCK_TREE),
+    token: null
+  });
+
+  assert.equal(result.skipped.length, 1);
+  assert.match(result.skipped[0].reason, /non-GitHub/);
+});
+
+test('checkSkillUpdates batches same-repo skills into one API call', async () => {
+  let fetchCount = 0;
+  const countingFetch = async (url, opts) => {
+    fetchCount++;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => MOCK_TREE
+    };
+  };
+
+  const lockSkills = {
+    'skill-a': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: 'old-hash-a',
+      skillPath: '.agents/skills/skill-a'
+    },
+    'skill-b': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: 'old-hash-b',
+      skillPath: '.agents/skills/skill-b'
+    }
+  };
+
+  await checkSkillUpdates(lockSkills, {}, {
+    fetchFn: countingFetch,
+    token: null
+  });
+
+  assert.equal(fetchCount, 1, 'Should only make one API call for same repo');
+});
+
+test('checkSkillUpdates handles network errors gracefully', async () => {
+  const lockSkills = {
+    'my-skill': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: 'abc123',
+      skillPath: '.agents/skills/my-skill'
+    }
+  };
+
+  const failFetch = async () => { throw new Error('Network unreachable'); };
+
+  const result = await checkSkillUpdates(lockSkills, {}, {
+    fetchFn: failFetch,
+    token: null
+  });
+
+  assert.equal(result.skipped.length, 1);
+  assert.match(result.skipped[0].reason, /network error/);
+});
+
+test('checkSkillUpdates handles rate limit (403)', async () => {
+  const lockSkills = {
+    'my-skill': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: 'abc123',
+      skillPath: '.agents/skills/my-skill'
+    }
+  };
+
+  const result = await checkSkillUpdates(lockSkills, {}, {
+    fetchFn: makeRateLimitFetchFn(),
+    token: null
+  });
+
+  assert.equal(result.skipped.length, 1);
+  assert.match(result.skipped[0].reason, /rate limited/);
+});
+
+test('checkSkillUpdates handles empty lockfile', async () => {
+  const result = await checkSkillUpdates({}, {}, {
+    fetchFn: makeFetchFn(MOCK_TREE),
+    token: null
+  });
+
+  assert.equal(result.upToDate.length, 0);
+  assert.equal(result.updatesAvailable.length, 0);
+  assert.equal(result.skipped.length, 0);
+});
+
+test('checkSkillUpdates also checks registry items', async () => {
+  const lockSkills = {};
+  const registryItems = {
+    'some-key': {
+      id: 'registry-skill',
+      externalSource: 'owner/repo',
+      externalSourceType: 'github',
+      externalSourceUrl: 'https://github.com/owner/repo',
+      externalHash: 'old-registry-hash'
+    }
+  };
+
+  const result = await checkSkillUpdates(lockSkills, registryItems, {
+    fetchFn: makeFetchFn(MOCK_TREE),
+    token: null
+  });
+
+  assert.equal(result.updatesAvailable.length + result.upToDate.length, 1);
+});
+
+// --- cmdCheck tests ---
+
+test('cmdCheck outputs text report with updates available', async () => {
+  const tmpDir = await makeTmpDir();
+  await initGitRepo(tmpDir);
+
+  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+  await writeProjectLockfile(tmpDir, {
+    version: 1,
+    skills: {
+      'up-to-date-skill': {
+        source: 'owner/repo-a',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/owner/repo-a',
+        computedHash: currentFingerprint,
+        skillPath: '.agents/skills/up-to-date-skill'
+      },
+      'outdated-skill': {
+        source: 'owner/repo-b',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/owner/repo-b',
+        computedHash: 'stale-hash',
+        skillPath: '.agents/skills/outdated-skill'
+      },
+      'local-skill': {
+        source: './local',
+        sourceType: 'local',
+        sourceUrl: null,
+        computedHash: null,
+        skillPath: '.agents/skills/local-skill'
+      }
+    }
+  });
+
+  const logs = [];
+  const origLog = console.log;
+  console.log = (...args) => logs.push(args.join(' '));
+
+  try {
+    await cmdCheck({ json: false }, {
+      projectRoot: tmpDir,
+      cwd: tmpDir,
+      _fetchFn: makeFetchFn(MOCK_TREE)
+    });
+  } finally {
+    console.log = origLog;
+  }
+
+  const output = logs.join('\n');
+  assert.match(output, /1 skill up to date/);
+  assert.match(output, /1 skill has updates available/);
+  assert.match(output, /outdated-skill/);
+  assert.match(output, /1 skill skipped/);
+});
+
+test('cmdCheck outputs JSON when --json flag is set', async () => {
+  const tmpDir = await makeTmpDir();
+  await initGitRepo(tmpDir);
+
+  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+  await writeProjectLockfile(tmpDir, {
+    version: 1,
+    skills: {
+      'my-skill': {
+        source: 'owner/repo',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/owner/repo',
+        computedHash: currentFingerprint,
+        skillPath: '.agents/skills/my-skill'
+      }
+    }
+  });
+
+  const logs = [];
+  const origLog = console.log;
+  console.log = (...args) => logs.push(args.join(' '));
+
+  try {
+    await cmdCheck({ json: true }, {
+      projectRoot: tmpDir,
+      cwd: tmpDir,
+      _fetchFn: makeFetchFn(MOCK_TREE)
+    });
+  } finally {
+    console.log = origLog;
+  }
+
+  const output = logs.join('\n');
+  const parsed = JSON.parse(output);
+  assert.ok(Array.isArray(parsed.upToDate));
+  assert.ok(Array.isArray(parsed.updatesAvailable));
+  assert.ok(Array.isArray(parsed.skipped));
+  assert.equal(parsed.upToDate.length, 1);
+  assert.equal(parsed.upToDate[0].name, 'my-skill');
+});
+
+test('cmdCheck JSON output has no ANSI escape codes', async () => {
+  const tmpDir = await makeTmpDir();
+  await initGitRepo(tmpDir);
+
+  await writeProjectLockfile(tmpDir, {
+    version: 1,
+    skills: {
+      'my-skill': {
+        source: 'owner/repo',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/owner/repo',
+        computedHash: 'old-hash',
+        skillPath: '.agents/skills/my-skill'
+      }
+    }
+  });
+
+  const logs = [];
+  const origLog = console.log;
+  console.log = (...args) => logs.push(args.join(' '));
+
+  try {
+    await cmdCheck({ json: true }, {
+      projectRoot: tmpDir,
+      cwd: tmpDir,
+      _fetchFn: makeFetchFn(MOCK_TREE)
+    });
+  } finally {
+    console.log = origLog;
+  }
+
+  const output = logs.join('\n');
+  // eslint-disable-next-line no-control-regex
+  assert.ok(!/\u001b/.test(output), 'JSON output should not contain ANSI escape codes');
+  const parsed = JSON.parse(output);
+  assert.ok(parsed);
+});
+
+test('cmdCheck shows no-skills message when lockfile is empty', async () => {
+  const tmpDir = await makeTmpDir();
+  await initGitRepo(tmpDir);
+
+  await writeProjectLockfile(tmpDir, { version: 1, skills: {} });
+
+  const logs = [];
+  const origLog = console.log;
+  console.log = (...args) => logs.push(args.join(' '));
+
+  try {
+    await cmdCheck({ json: false }, {
+      projectRoot: tmpDir,
+      cwd: tmpDir,
+      _fetchFn: makeFetchFn(MOCK_TREE)
+    });
+  } finally {
+    console.log = origLog;
+  }
+
+  const output = logs.join('\n');
+  assert.match(output, /No tracked skills found/);
+});
+
+test('cmdCheck --json returns empty arrays when no skills tracked', async () => {
+  const tmpDir = await makeTmpDir();
+  await initGitRepo(tmpDir);
+
+  await writeProjectLockfile(tmpDir, { version: 1, skills: {} });
+
+  const logs = [];
+  const origLog = console.log;
+  console.log = (...args) => logs.push(args.join(' '));
+
+  try {
+    await cmdCheck({ json: true }, {
+      projectRoot: tmpDir,
+      cwd: tmpDir,
+      _fetchFn: makeFetchFn(MOCK_TREE)
+    });
+  } finally {
+    console.log = origLog;
+  }
+
+  const output = logs.join('\n');
+  const parsed = JSON.parse(output);
+  assert.deepEqual(parsed.upToDate, []);
+  assert.deepEqual(parsed.updatesAvailable, []);
+  assert.deepEqual(parsed.skipped, []);
+});
+
+// --- cmdUpdate tests ---
+
+test('cmdUpdate --dry-run does not modify files', async () => {
+  const tmpDir = await makeTmpDir();
+  await initGitRepo(tmpDir);
+
+  await writeProjectLockfile(tmpDir, {
+    version: 1,
+    skills: {
+      'my-skill': {
+        source: 'owner/repo',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/owner/repo',
+        computedHash: 'stale-hash',
+        skillPath: '.agents/skills/my-skill'
+      }
+    }
+  });
+
+  const logs = [];
+  const origLog = console.log;
+  console.log = (...args) => logs.push(args.join(' '));
+
+  try {
+    await cmdUpdate({ 'dry-run': true, scope: 'project' }, [], {
+      projectRoot: tmpDir,
+      cwd: tmpDir,
+      _fetchFn: makeFetchFn(MOCK_TREE)
+    });
+  } finally {
+    console.log = origLog;
+  }
+
+  const output = logs.join('\n');
+  assert.match(output, /dry-run/i);
+  assert.match(output, /my-skill/);
+
+  const lockData = await readProjectLockfile(tmpDir);
+  assert.equal(lockData.skills['my-skill'].computedHash, 'stale-hash', 'Hash should not change in dry-run');
+});
+
+test('cmdUpdate shows no-skills message for empty lockfile', async () => {
+  const tmpDir = await makeTmpDir();
+  await initGitRepo(tmpDir);
+
+  await writeProjectLockfile(tmpDir, { version: 1, skills: {} });
+
+  const logs = [];
+  const origLog = console.log;
+  console.log = (...args) => logs.push(args.join(' '));
+
+  try {
+    await cmdUpdate({ scope: 'project' }, [], {
+      projectRoot: tmpDir,
+      cwd: tmpDir,
+      _fetchFn: makeFetchFn(MOCK_TREE)
+    });
+  } finally {
+    console.log = origLog;
+  }
+
+  const output = logs.join('\n');
+  assert.match(output, /No tracked skills found/);
+});
+
+test('cmdUpdate shows already-up-to-date message', async () => {
+  const tmpDir = await makeTmpDir();
+  await initGitRepo(tmpDir);
+
+  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+  await writeProjectLockfile(tmpDir, {
+    version: 1,
+    skills: {
+      'my-skill': {
+        source: 'owner/repo',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/owner/repo',
+        computedHash: currentFingerprint,
+        skillPath: '.agents/skills/my-skill'
+      }
+    }
+  });
+
+  const logs = [];
+  const origLog = console.log;
+  console.log = (...args) => logs.push(args.join(' '));
+
+  try {
+    await cmdUpdate({ scope: 'project' }, [], {
+      projectRoot: tmpDir,
+      cwd: tmpDir,
+      _fetchFn: makeFetchFn(MOCK_TREE)
+    });
+  } finally {
+    console.log = origLog;
+  }
+
+  const output = logs.join('\n');
+  assert.match(output, /already up to date/);
+});
+
+test('cmdUpdate rejects invalid --scope', async () => {
+  const tmpDir = await makeTmpDir();
+  await initGitRepo(tmpDir);
+
+  await assert.rejects(
+    () => cmdUpdate({ scope: 'invalid' }, [], {
+      projectRoot: tmpDir,
+      cwd: tmpDir,
+      _fetchFn: makeFetchFn(MOCK_TREE)
+    }),
+    /Invalid --scope/
+  );
+});
+
+// --- CLI process tests ---
+
+test('skillsdock check --help shows check in help text', () => {
+  const result = spawnSync(process.execPath, [cliPath, '--help'], {
+    encoding: 'utf8',
+    env: { ...process.env }
+  });
+  assert.match(result.stdout, /check/);
+  assert.match(result.stdout, /update/);
+});
+
+test('skillsdock check works via CLI process', async () => {
+  const tmpDir = await makeTmpDir();
+  await initGitRepo(tmpDir);
+
+  await writeProjectLockfile(tmpDir, { version: 1, skills: {} });
+
+  const result = spawnSync(process.execPath, [cliPath, 'check'], {
+    cwd: tmpDir,
+    encoding: 'utf8',
+    env: { ...process.env }
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /No tracked skills found/);
+});
+
+test('skillsdock update works via CLI process', async () => {
+  const tmpDir = await makeTmpDir();
+  await initGitRepo(tmpDir);
+
+  await writeProjectLockfile(tmpDir, { version: 1, skills: {} });
+
+  const result = spawnSync(process.execPath, [cliPath, 'update', '--scope', 'project'], {
+    cwd: tmpDir,
+    encoding: 'utf8',
+    env: { ...process.env }
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /No tracked skills found/);
+});
+
+// --- Mixed scenario tests ---
+
+test('checkSkillUpdates handles mix of up-to-date, outdated, and skipped skills', async () => {
+  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+  const lockSkills = {
+    'fresh-skill': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: currentFingerprint,
+      skillPath: '.agents/skills/fresh-skill'
+    },
+    'stale-skill': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: 'stale-hash-value',
+      skillPath: '.agents/skills/stale-skill'
+    },
+    'local-only': {
+      source: './local',
+      sourceType: 'local',
+      sourceUrl: null,
+      computedHash: null,
+      skillPath: '.agents/skills/local-only'
+    }
+  };
+
+  const result = await checkSkillUpdates(lockSkills, {}, {
+    fetchFn: makeFetchFn(MOCK_TREE),
+    token: null
+  });
+
+  assert.equal(result.upToDate.length, 1);
+  assert.equal(result.upToDate[0].name, 'fresh-skill');
+  assert.equal(result.updatesAvailable.length, 1);
+  assert.equal(result.updatesAvailable[0].name, 'stale-skill');
+  assert.ok(result.skipped.length >= 1);
+  assert.ok(result.skipped.some((s) => s.name === 'local-only'));
+});
+
+test('checkSkillUpdates updatesAvailable contains correct fields', async () => {
+  const lockSkills = {
+    'my-skill': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: 'old-hash',
+      skillPath: '.agents/skills/my-skill'
+    }
+  };
+
+  const result = await checkSkillUpdates(lockSkills, {}, {
+    fetchFn: makeFetchFn(MOCK_TREE),
+    token: null
+  });
+
+  assert.equal(result.updatesAvailable.length, 1);
+  const update = result.updatesAvailable[0];
+  assert.ok(update.name);
+  assert.ok(update.source);
+  assert.ok(update.currentHash);
+  assert.ok(update.remoteHash);
+});

--- a/test/check-update.test.mjs
+++ b/test/check-update.test.mjs
@@ -845,3 +845,51 @@ test('checkSkillUpdates uses per-skill repoSubpath for fingerprinting', async ()
   assert.equal(result.upToDate.length, 1, 'skill-b should be up to date');
   assert.equal(result.upToDate[0].name, 'skill-b');
 });
+
+test('checkSkillUpdates uses userLockSkills with treeSha for user-scope freshness', async () => {
+  const currentTreeSha = computeTreeFingerprint(MOCK_TREE, '');
+  const userLockSkills = {
+    'user-skill': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: 'local-content-hash',
+      treeSha: currentTreeSha,
+      skillPath: 'user-skill/SKILL.md'
+    }
+  };
+
+  const result = await checkSkillUpdates({}, {}, {
+    fetchFn: makeFetchFn(MOCK_TREE),
+    token: null,
+    userLockSkills
+  });
+
+  assert.equal(result.upToDate.length, 1, 'user-skill should be up to date');
+  assert.equal(result.upToDate[0].name, 'user-skill');
+  assert.equal(result.updatesAvailable.length, 0);
+});
+
+test('checkSkillUpdates detects user-scope update when remote tree changes', async () => {
+  const oldTreeSha = computeTreeFingerprint(MOCK_TREE, '');
+  const userLockSkills = {
+    'user-skill': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: 'local-content-hash',
+      treeSha: oldTreeSha,
+      skillPath: 'user-skill/SKILL.md'
+    }
+  };
+
+  const result = await checkSkillUpdates({}, {}, {
+    fetchFn: makeFetchFn(UPDATED_TREE),
+    token: null,
+    userLockSkills
+  });
+
+  assert.equal(result.updatesAvailable.length, 1);
+  assert.equal(result.updatesAvailable[0].name, 'user-skill');
+  assert.equal(result.upToDate.length, 0);
+});

--- a/test/check-update.test.mjs
+++ b/test/check-update.test.mjs
@@ -89,6 +89,7 @@ import crypto from 'node:crypto';
 function computeTreeFingerprint(treeData, subpath) {
   const prefix = subpath ? (subpath.endsWith('/') ? subpath : subpath + '/') : '';
   const relevant = treeData.tree.filter((entry) => {
+    if (entry.type !== 'blob') return false;
     if (!prefix) return true;
     return entry.path === subpath || entry.path.startsWith(prefix);
   });
@@ -154,13 +155,14 @@ test('resolveGitHubToken returns null when no token available', () => {
 // --- checkSkillUpdates tests ---
 
 test('checkSkillUpdates detects updates available', async () => {
-  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+  const oldTreeSha = computeTreeFingerprint(MOCK_TREE, '');
   const lockSkills = {
     'my-skill': {
       source: 'test-owner/test-repo',
       sourceType: 'github',
       sourceUrl: 'https://github.com/test-owner/test-repo',
-      computedHash: currentFingerprint,
+      computedHash: 'local-content-hash',
+      treeSha: oldTreeSha,
       skillPath: '.agents/skills/my-skill'
     }
   };
@@ -175,14 +177,15 @@ test('checkSkillUpdates detects updates available', async () => {
   assert.equal(result.upToDate.length, 0);
 });
 
-test('checkSkillUpdates reports up-to-date when hashes match', async () => {
-  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+test('checkSkillUpdates reports up-to-date when treeSha matches', async () => {
+  const currentTreeSha = computeTreeFingerprint(MOCK_TREE, '');
   const lockSkills = {
     'my-skill': {
       source: 'test-owner/test-repo',
       sourceType: 'github',
       sourceUrl: 'https://github.com/test-owner/test-repo',
-      computedHash: currentFingerprint,
+      computedHash: 'local-content-hash',
+      treeSha: currentTreeSha,
       skillPath: '.agents/skills/my-skill'
     }
   };
@@ -352,7 +355,7 @@ test('cmdCheck outputs text report with updates available', async () => {
   const tmpDir = await makeTmpDir();
   await initGitRepo(tmpDir);
 
-  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+  const currentTreeSha = computeTreeFingerprint(MOCK_TREE, '');
   await writeProjectLockfile(tmpDir, {
     version: 1,
     skills: {
@@ -360,14 +363,16 @@ test('cmdCheck outputs text report with updates available', async () => {
         source: 'owner/repo-a',
         sourceType: 'github',
         sourceUrl: 'https://github.com/owner/repo-a',
-        computedHash: currentFingerprint,
+        computedHash: 'local-hash',
+        treeSha: currentTreeSha,
         skillPath: '.agents/skills/up-to-date-skill'
       },
       'outdated-skill': {
         source: 'owner/repo-b',
         sourceType: 'github',
         sourceUrl: 'https://github.com/owner/repo-b',
-        computedHash: 'stale-hash',
+        computedHash: 'local-hash',
+        treeSha: 'stale-tree-sha',
         skillPath: '.agents/skills/outdated-skill'
       },
       'local-skill': {
@@ -405,7 +410,7 @@ test('cmdCheck outputs JSON when --json flag is set', async () => {
   const tmpDir = await makeTmpDir();
   await initGitRepo(tmpDir);
 
-  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+  const currentTreeSha = computeTreeFingerprint(MOCK_TREE, '');
   await writeProjectLockfile(tmpDir, {
     version: 1,
     skills: {
@@ -413,7 +418,8 @@ test('cmdCheck outputs JSON when --json flag is set', async () => {
         source: 'owner/repo',
         sourceType: 'github',
         sourceUrl: 'https://github.com/owner/repo',
-        computedHash: currentFingerprint,
+        computedHash: 'local-hash',
+        treeSha: currentTreeSha,
         skillPath: '.agents/skills/my-skill'
       }
     }
@@ -453,7 +459,8 @@ test('cmdCheck JSON output has no ANSI escape codes', async () => {
         source: 'owner/repo',
         sourceType: 'github',
         sourceUrl: 'https://github.com/owner/repo',
-        computedHash: 'old-hash',
+        computedHash: 'local-hash',
+        treeSha: 'old-tree-sha',
         skillPath: '.agents/skills/my-skill'
       }
     }
@@ -600,7 +607,7 @@ test('cmdUpdate shows already-up-to-date message', async () => {
   const tmpDir = await makeTmpDir();
   await initGitRepo(tmpDir);
 
-  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+  const currentTreeSha = computeTreeFingerprint(MOCK_TREE, '');
   await writeProjectLockfile(tmpDir, {
     version: 1,
     skills: {
@@ -608,7 +615,8 @@ test('cmdUpdate shows already-up-to-date message', async () => {
         source: 'owner/repo',
         sourceType: 'github',
         sourceUrl: 'https://github.com/owner/repo',
-        computedHash: currentFingerprint,
+        computedHash: 'local-hash',
+        treeSha: currentTreeSha,
         skillPath: '.agents/skills/my-skill'
       }
     }
@@ -692,20 +700,22 @@ test('skillsdock update works via CLI process', async () => {
 // --- Mixed scenario tests ---
 
 test('checkSkillUpdates handles mix of up-to-date, outdated, and skipped skills', async () => {
-  const currentFingerprint = computeTreeFingerprint(MOCK_TREE, '');
+  const currentTreeSha = computeTreeFingerprint(MOCK_TREE, '');
   const lockSkills = {
     'fresh-skill': {
       source: 'owner/repo',
       sourceType: 'github',
       sourceUrl: 'https://github.com/owner/repo',
-      computedHash: currentFingerprint,
+      computedHash: 'local-hash',
+      treeSha: currentTreeSha,
       skillPath: '.agents/skills/fresh-skill'
     },
     'stale-skill': {
       source: 'owner/repo',
       sourceType: 'github',
       sourceUrl: 'https://github.com/owner/repo',
-      computedHash: 'stale-hash-value',
+      computedHash: 'local-hash',
+      treeSha: 'stale-tree-sha',
       skillPath: '.agents/skills/stale-skill'
     },
     'local-only': {
@@ -731,18 +741,20 @@ test('checkSkillUpdates handles mix of up-to-date, outdated, and skipped skills'
 });
 
 test('checkSkillUpdates updatesAvailable contains correct fields', async () => {
+  const oldTreeSha = computeTreeFingerprint(MOCK_TREE, '');
   const lockSkills = {
     'my-skill': {
       source: 'owner/repo',
       sourceType: 'github',
       sourceUrl: 'https://github.com/owner/repo',
-      computedHash: 'old-hash',
+      computedHash: 'local-hash',
+      treeSha: oldTreeSha,
       skillPath: '.agents/skills/my-skill'
     }
   };
 
   const result = await checkSkillUpdates(lockSkills, {}, {
-    fetchFn: makeFetchFn(MOCK_TREE),
+    fetchFn: makeFetchFn(UPDATED_TREE),
     token: null
   });
 
@@ -752,4 +764,26 @@ test('checkSkillUpdates updatesAvailable contains correct fields', async () => {
   assert.ok(update.source);
   assert.ok(update.currentHash);
   assert.ok(update.remoteHash);
+  assert.notEqual(update.currentHash, update.remoteHash);
+});
+
+test('checkSkillUpdates flags entries without treeSha as needing update', async () => {
+  const lockSkills = {
+    'legacy-skill': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: 'local-content-hash-only',
+      skillPath: '.agents/skills/legacy-skill'
+    }
+  };
+
+  const result = await checkSkillUpdates(lockSkills, {}, {
+    fetchFn: makeFetchFn(MOCK_TREE),
+    token: null
+  });
+
+  assert.equal(result.updatesAvailable.length, 1);
+  assert.equal(result.updatesAvailable[0].name, 'legacy-skill');
+  assert.equal(result.updatesAvailable[0].currentHash, null);
 });

--- a/test/check-update.test.mjs
+++ b/test/check-update.test.mjs
@@ -36,11 +36,10 @@ async function initGitRepo(dir) {
 
 function makeFetchFn(treeResponse) {
   return async (url, opts) => {
-    return {
-      ok: true,
-      status: 200,
-      json: async () => treeResponse
-    };
+    if (url.includes('/git/trees/')) {
+      return { ok: true, status: 200, json: async () => treeResponse };
+    }
+    return { ok: true, status: 200, json: async () => ({ default_branch: 'main' }) };
   };
 }
 
@@ -240,14 +239,13 @@ test('checkSkillUpdates skips non-GitHub sources', async () => {
 });
 
 test('checkSkillUpdates batches same-repo skills into one API call', async () => {
-  let fetchCount = 0;
+  let treeCallCount = 0;
   const countingFetch = async (url, opts) => {
-    fetchCount++;
-    return {
-      ok: true,
-      status: 200,
-      json: async () => MOCK_TREE
-    };
+    if (url.includes('/git/trees/')) {
+      treeCallCount++;
+      return { ok: true, status: 200, json: async () => MOCK_TREE };
+    }
+    return { ok: true, status: 200, json: async () => ({ default_branch: 'main' }) };
   };
 
   const lockSkills = {
@@ -272,7 +270,7 @@ test('checkSkillUpdates batches same-repo skills into one API call', async () =>
     token: null
   });
 
-  assert.equal(fetchCount, 1, 'Should only make one API call for same repo');
+  assert.equal(treeCallCount, 1, 'Should only make one tree API call for same repo');
 });
 
 test('checkSkillUpdates handles network errors gracefully', async () => {

--- a/test/check-update.test.mjs
+++ b/test/check-update.test.mjs
@@ -787,3 +787,61 @@ test('checkSkillUpdates flags entries without treeSha as needing update', async 
   assert.equal(result.updatesAvailable[0].name, 'legacy-skill');
   assert.equal(result.updatesAvailable[0].currentHash, null);
 });
+
+test('checkSkillUpdates uses per-skill repoSubpath for fingerprinting', async () => {
+  const MULTI_SKILL_TREE = {
+    sha: 'root-sha',
+    tree: [
+      { path: 'skills/skill-a/SKILL.md', type: 'blob', sha: 'a-skill-sha' },
+      { path: 'skills/skill-a/index.js', type: 'blob', sha: 'a-index-sha' },
+      { path: 'skills/skill-b/SKILL.md', type: 'blob', sha: 'b-skill-sha' },
+      { path: 'skills/skill-b/index.js', type: 'blob', sha: 'b-index-sha' }
+    ]
+  };
+
+  const CHANGED_TREE = {
+    sha: 'changed-root',
+    tree: [
+      { path: 'skills/skill-a/SKILL.md', type: 'blob', sha: 'a-skill-sha-CHANGED' },
+      { path: 'skills/skill-a/index.js', type: 'blob', sha: 'a-index-sha' },
+      { path: 'skills/skill-b/SKILL.md', type: 'blob', sha: 'b-skill-sha' },
+      { path: 'skills/skill-b/index.js', type: 'blob', sha: 'b-index-sha' }
+    ]
+  };
+
+  const treeShaA = computeTreeFingerprint(MULTI_SKILL_TREE, 'skills/skill-a');
+  const treeShaB = computeTreeFingerprint(MULTI_SKILL_TREE, 'skills/skill-b');
+
+  assert.notEqual(treeShaA, treeShaB, 'Per-skill fingerprints should differ');
+
+  const lockSkills = {
+    'skill-a': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: 'local-a',
+      treeSha: treeShaA,
+      repoSubpath: 'skills/skill-a',
+      skillPath: '.agents/skills/skill-a'
+    },
+    'skill-b': {
+      source: 'owner/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/owner/repo',
+      computedHash: 'local-b',
+      treeSha: treeShaB,
+      repoSubpath: 'skills/skill-b',
+      skillPath: '.agents/skills/skill-b'
+    }
+  };
+
+  const result = await checkSkillUpdates(lockSkills, {}, {
+    fetchFn: makeFetchFn(CHANGED_TREE),
+    token: null
+  });
+
+  assert.equal(result.updatesAvailable.length, 1, 'Only skill-a should need update');
+  assert.equal(result.updatesAvailable[0].name, 'skill-a');
+  assert.equal(result.upToDate.length, 1, 'skill-b should be up to date');
+  assert.equal(result.upToDate[0].name, 'skill-b');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #19

## Summary

Implements two new CLI commands — `skillsdock check` and `skillsdock update` — for detecting and applying skill updates via the GitHub Trees API.

## Changes

### `skillsdock check [--json]`

- Reads tracked skills from `skills-lock.json`, the external `.skill-lock.json` (user scope), and the SkillsDock registry
- Fetches remote tree data via GitHub Trees API (`GET /repos/{owner}/{repo}/git/trees/{branch}?recursive=1`)
- **Batches skills per repository + branch** — one API call per unique `owner/repo#branch`, avoiding N+1 queries
- Resolves default branch via repo metadata API (`GET /repos/:owner/:repo`) when no branch is specified, instead of hardcoding `main`
- Computes a SHA-256 fingerprint from remote tree blob SHAs and compares against a locally stored `treeSha` field (same hash domain as GitHub API — no false positives from content-vs-git-object hash mismatches)
- **Per-skill fingerprinting**: each skill gets its own `treeSha` computed from its repo-relative subdirectory, so sibling skills in the same repo are independently tracked
- Text output: shows up-to-date count, skills with updates available (with source), and skipped skills with reasons
- `--json` flag: outputs clean machine-readable JSON without ANSI escape codes
- Gracefully handles: network errors, API rate limits (403/429), non-GitHub sources, missing source URLs

### `skillsdock update [--scope user|project] [--dry-run]`

- Runs the same freshness detection as `check`
- **Scope-aware**: filters updates by the chosen scope and writes to the correct lockfile
  - `--scope project`: updates `skills-lock.json` via `updateLockfileEntry`
  - `--scope user`: updates `~/.agents/.skill-lock.json` via `writeExternalSkillLock` (with `treeSha` and `repoSubpath` persisted)
- **Atomic install**: installs to a staging directory, computes hash, then atomically renames to the final destination — prevents stale files and partial updates
- Re-clones and re-installs outdated skills using `installSkillToTarget()`
- Stores both `computedHash` (local content SHA-256) and `treeSha` (per-skill git blob fingerprint) in lockfile entries for both scopes
- `--dry-run` previews which skills would be updated without writing files
- Prints update summary

### Hash domain consistency

- `buildTreeFingerprint()` uses GitHub API blob SHAs (git object SHA-1) to build a fingerprint
- `computeLocalTreeFingerprint()` uses `git ls-tree -r HEAD` on cloned repos to produce fingerprints in the **same domain** as the GitHub API
- `treeSha` field in lockfile entries stores this per-skill fingerprint at install time
- `repoSubpath` field tracks each skill's directory relative to the repo root
- Both fields are persisted in project `skills-lock.json` AND user-scope `.skill-lock.json`
- `check` compares remote fingerprint against `treeSha` using the per-skill `repoSubpath`
- Pre-existing entries without `treeSha` are flagged as needing update (one-time migration)

### `resolveGitHubToken()`

- Priority: `GITHUB_TOKEN` > `GH_TOKEN` > `gh auth token` CLI fallback
- Works without a token (60 req/hr unauthenticated); shows helpful message on rate limit

### Registry/lockfile dedupe

- Dedupes registry items vs lockfile entries by matching **both** `sourceUrl` **and** skill identity (name/skillPath), not just `sourceUrl` alone — prevents multi-skill repos from being incorrectly deduplicated
- User lock entries take priority over registry items when both are present

### Other

- Exported `installSkillToTarget` for reuse in `cmdUpdate`
- Registered `check` and `update` in `runCli()` routing and `printHelp()`
- Updated `CHANGELOG.md` and `README.md` with usage docs, examples, and output format samples
- Fixed README Text Output code fence language tag (markdownlint MD040)
- `mapExternalSkillLockEntry` and `writeExternalSkillLock` now round-trip `treeSha` and `repoSubpath`

## Tests

30 new tests in `test/check-update.test.mjs` covering:

- `resolveGitHubToken` priority (GITHUB_TOKEN > GH_TOKEN)
- Update detection via `treeSha` (up-to-date, outdated, mixed scenarios)
- Legacy entries without `treeSha` flagged as needing update
- **Per-skill fingerprinting**: multi-skill repo where only one skill changes — verifies sibling stays up-to-date
- **User-scope treeSha round-trip**: verifies `userLockSkills` with `treeSha` correctly reports up-to-date and stale states
- Batch API calls (single tree fetch per repo verification, with repo metadata routing)
- No source URL / non-GitHub source skipping
- Network error and rate limit graceful degradation
- `cmdCheck` text and JSON output format
- Empty lockfile handling ("No tracked skills found" message)
- `cmdUpdate --dry-run` (no file modifications)
- `cmdUpdate` invalid scope rejection
- CLI process integration tests

## Quality Gates

- All 253 tests pass (195 existing + 28 find + 30 new)
- `npm run pack:check` passes
- No existing tests broken
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-379c73e0-22c6-4af1-b87e-51281eb610e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-379c73e0-22c6-4af1-b87e-51281eb610e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 CLI：`skillsdock check [--json]`（按每技能 `treeSha` 与远端仓库树指纹比对更新状况、按仓库批量请求、跳过非 GitHub 源、JSON 输出无 ANSI、优雅处理网络/限流故障）。
  * 新增 CLI：`skillsdock update [--scope user|project] [--dry-run]`（重装过期技能并更新 `skills-lock.json`，dry-run 可预览变更）。
  * 项目安装现在在锁文件中记录每技能的仓库子路径并在安装时计算 `treeSha`。

* **文档**
  * 更新 README/CHANGELOG：新增 `treeSha` 字段说明、Token 解析优先级、命令用法与示例、限流提示与 legacy 锁条目处理规则。

* **测试**
  * 新增测试套件覆盖 token 解析、批量检测、限流/错误场景、JSON/文本输出、dry-run 与 CLI 集成。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->